### PR TITLE
ST-767 Remove "via email" from text

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -77,4 +77,11 @@
       <cve>CVE-2021-37533</cve>
       <cve>CVE-2021-4277</cve>
     </suppress>
+    <suppress base="true">
+      <notes><![CDATA[
+     FP per issue #5233
+     ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+      <cpe>cpe:/a:yaml_project:yaml</cpe>
+    </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecision.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecision.java
@@ -113,7 +113,7 @@ public class CaseworkerIssueFinalDecision implements CCDConfig<CaseData, State, 
             recipients.add(RESPONDENT.getLabel());
         }
         return SubmittedCallbackResponse.builder()
-            .confirmationHeader(format("# Final decision notice issued %n## A copy of this decision notice has been sent via email to: %s",
+            .confirmationHeader(format("# Final decision notice issued %n## A copy of this decision notice has been sent to: %s",
                 String.join(", ", recipients)))
             .build();
     }

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecisionTest.java
@@ -116,7 +116,7 @@ class CaseworkerIssueFinalDecisionTest {
         //Then
         assertThat(response.getConfirmationHeader())
             .isEqualTo("# Final decision notice issued \n"
-                + "## A copy of this decision notice has been sent via email to: Subject, Representative, Respondent");
+                + "## A copy of this decision notice has been sent to: Subject, Representative, Respondent");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ST-765

### Change description ###

Remove redundant text referencing notification method (email).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
