### PR TITLE
Bump com.github.hmcts.rse-cft-lib from 0.19.579 to 0.19.592

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
   id 'org.springframework.boot' version '2.7.5'
   id 'com.github.ben-manes.versions' version '0.41.0'
   id 'hmcts.ccd.sdk'  version '5.3.0'
-  id 'com.github.hmcts.rse-cft-lib' version '0.19.579'
+  id 'com.github.hmcts.rse-cft-lib' version '0.19.592'
 }
 
 apply plugin: 'cz.habarta.typescript-generator'


### PR DESCRIPTION
Bumps com.github.hmcts.rse-cft-lib from 0.19.579 to 0.19.592.

---
updated-dependencies:
- dependency-name: com.github.hmcts.rse-cft-lib dependency-type: direct:production update-type: version-update:semver-patch ...

### Change description ###

Enter a description.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SPTRIBS-

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

