### PR TITLE
Bump org.sonarqube from 3.4.0.2513 to 4.0.0.2929

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'org.owasp.dependencycheck' version '8.0.2'
-  id 'org.sonarqube' version '3.4.0.2513'
+  id 'org.sonarqube' version '4.0.0.2929'
   id 'io.spring.dependency-management' version '1.0.13.RELEASE'
   id 'org.springframework.boot' version '2.7.5'
   id 'com.github.ben-manes.versions' version '0.41.0'


### PR DESCRIPTION
Bumps org.sonarqube from 3.4.0.2513 to 4.0.0.2929.

---
updated-dependencies:
- dependency-name: org.sonarqube dependency-type: direct:production update-type: version-update:semver-major ...

### Change description ###

Enter a description.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SPTRIBS-

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

