### PR TITLE
ST-1061 Implement alternative solution

### DIFF
--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseWorkerCreateDraftOrder.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseWorkerCreateDraftOrder.java
@@ -97,10 +97,8 @@ public class CaseWorkerCreateDraftOrder implements CCDConfig<CaseData, State, Us
         var caseData = details.getData();
         OrderTemplate orderTemplate = caseData.getDraftOrderContentCIC().getOrderTemplate();
 
-        DynamicListElement addedElement = addToDraftOrderTemplatesDynamicList(orderTemplate, caseData.getCicCase());
-        UUID code = addedElement.getCode();
+        addToDraftOrderTemplatesDynamicList(orderTemplate, caseData.getCicCase());
         DraftOrderCIC draftOrderCIC = DraftOrderCIC.builder()
-            .code(code.toString())
             .draftOrderContentCIC(caseData.getDraftOrderContentCIC())
             .template(orderTemplate)
             .templateGeneratedDocument(caseData.getCicCase().getOrderTemplateIssued())
@@ -138,7 +136,7 @@ public class CaseWorkerCreateDraftOrder implements CCDConfig<CaseData, State, Us
             .build();
     }
 
-    private DynamicListElement addToDraftOrderTemplatesDynamicList(final OrderTemplate orderTemplate, CicCase cicCase) {
+    private void addToDraftOrderTemplatesDynamicList(final OrderTemplate orderTemplate, CicCase cicCase) {
         DynamicList orderTemplateDynamicList = cicCase.getDraftOrderDynamicList();
         if (orderTemplateDynamicList == null) {
             orderTemplateDynamicList = DynamicList.builder().listItems(new ArrayList<>()).build();
@@ -150,7 +148,6 @@ public class CaseWorkerCreateDraftOrder implements CCDConfig<CaseData, State, Us
 
         DynamicListElement element = DynamicListElement.builder().label(templateNamePlusCurrentDate).code(UUID.randomUUID()).build();
         orderTemplateDynamicList.getListItems().add(element);
-        return element;
     }
 
     public SubmittedCallbackResponse draftCreated(CaseDetails<CaseData, State> details,

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/model/DraftOrderCIC.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/model/DraftOrderCIC.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.sptribs.caseworker.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,13 +18,6 @@ import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
 @AllArgsConstructor
 @Builder
 public class DraftOrderCIC {
-
-    @CCD(
-        label = "Code",
-        access = {DefaultAccess.class, CaseworkerWithCAAAccess.class}
-    )
-    @JsonIgnore
-    private String code;
 
     @CCD(
         label = "Template",

--- a/src/test/java/uk/gov/hmcts/sptribs/common/event/page/EditDraftOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/common/event/page/EditDraftOrderTest.java
@@ -34,7 +34,10 @@ public class EditDraftOrderTest {
         final DynamicListElement element = DynamicListElement.builder()
             .code(UUID.randomUUID())
             .build();
+        final List<DynamicListElement> elements = new ArrayList<>();
+        elements.add(element);
         final DynamicList dynamicList = DynamicList.builder()
+            .listItems(elements)
             .value(element)
             .build();
         final List<ListValue<DraftOrderCIC>> draftOrderCICList = new ArrayList<>();
@@ -44,7 +47,6 @@ public class EditDraftOrderTest {
             .orderTemplate(OrderTemplate.CIC6_GENERAL_DIRECTIONS)
             .build();
         DraftOrderCIC orderCIC = DraftOrderCIC.builder()
-            .code(element.getCode().toString())
             .draftOrderContentCIC(contentCIC)
             .build();
         ListValue<DraftOrderCIC> listValue = ListValue.<DraftOrderCIC>builder()


### PR DESCRIPTION
### Change description ###

Removed the UUID from DraftOrderCIC because
otherwise it displays on the order tab.
Implemented an alternative solution for populating the fields with the order currently being edited.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ST-1061

