### PR TITLE
ST-1078 Add dss create event and case fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/CaseData.java
@@ -237,6 +237,11 @@ public class CaseData {
         access = {DefaultAccess.class, CaseworkerWithCAAAccess.class})
     private CloseCase closeCase = new CloseCase();
 
+    @JsonUnwrapped(prefix = "dssCaseData")
+    @Builder.Default
+    @CCD(access = {DefaultAccess.class, CaseworkerWithCAAAccess.class})
+    private DssCaseData dssCaseData = new DssCaseData();
+
     @JsonIgnore
     public String formatCaseRef(long caseId) {
         String temp = format("%016d", caseId);

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/DssCaseData.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/DssCaseData.java
@@ -1,0 +1,126 @@
+package uk.gov.hmcts.sptribs.ciccase.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+import uk.gov.hmcts.sptribs.ciccase.model.access.CaseworkerWithCAAAccess;
+import uk.gov.hmcts.sptribs.ciccase.model.access.DefaultAccess;
+import uk.gov.hmcts.sptribs.common.MappableObject;
+import uk.gov.hmcts.sptribs.document.model.EdgeCaseDocument;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static uk.gov.hmcts.ccd.sdk.type.FieldType.Collection;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class DssCaseData implements MappableObject {
+
+    @CCD(
+        label = "caseTypeOfApplication",
+        access = {CaseworkerWithCAAAccess.class}
+    )
+    private String caseTypeOfApplication;
+
+    @CCD(
+        label = "Subject Full Name",
+        access = {DefaultAccess.class}
+    )
+    private String subjectFullName;
+
+    @CCD(
+        label = "Subject Date of Birth",
+        access = {DefaultAccess.class}
+    )
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate subjectDateOfBirth;
+
+    @CCD(
+        label = "Subject Email Address",
+        access = {DefaultAccess.class}
+    )
+    private String subjectEmailAddress;
+
+    @CCD(
+        label = "Subject Contact Number",
+        access = {DefaultAccess.class}
+    )
+    private String subjectContactNumber;
+
+    @CCD(
+        label = "Subject Agree To Be Contacted",
+        access = {DefaultAccess.class}
+    )
+    private YesOrNo subjectAgreeContact;
+
+    @CCD(
+        label = "Named Representative",
+        access = {DefaultAccess.class}
+    )
+    private YesOrNo representation;
+
+    @CCD(
+        label = "Named Representative Qualified",
+        access = {DefaultAccess.class}
+    )
+    private YesOrNo representationQualified;
+
+    @CCD(
+        label = "Representative Full Name",
+        access = {DefaultAccess.class}
+    )
+    private String representativeFullName;
+
+    @CCD(
+        label = "Representative Organisation Name",
+        access = {DefaultAccess.class}
+    )
+    private String representativeOrganisationName;
+
+    @CCD(
+        label = "Representative Contact Number",
+        access = {DefaultAccess.class}
+    )
+    private String representativeContactNumber;
+
+    @CCD(
+        label = "Representative Email Address",
+        access = {DefaultAccess.class}
+    )
+    private String representativeEmailAddress;
+
+    @CCD(
+        label = "Tribunal form uploaded documents",
+        typeOverride = Collection,
+        typeParameterOverride = "EdgeCaseDocument",
+        access = {DefaultAccess.class}
+    )
+    private List<ListValue<EdgeCaseDocument>> tribunalFormDocuments;
+
+    @CCD(
+        label = "Supporting uploaded documents",
+        typeOverride = Collection,
+        typeParameterOverride = "EdgeCaseDocument",
+        access = {DefaultAccess.class}
+    )
+    private List<ListValue<EdgeCaseDocument>> supportingDocuments;
+
+    @CCD(
+        label = "Other information uploaded documents",
+        typeOverride = Collection,
+        typeParameterOverride = "EdgeCaseDocument",
+        access = {DefaultAccess.class}
+    )
+    private List<ListValue<EdgeCaseDocument>> otherInfoDocuments;
+
+}

--- a/src/main/java/uk/gov/hmcts/sptribs/citizen/event/CicCreateCaseEvent.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/citizen/event/CicCreateCaseEvent.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.sptribs.citizen.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
+import uk.gov.hmcts.sptribs.ciccase.model.State;
+import uk.gov.hmcts.sptribs.ciccase.model.UserRole;
+
+import java.util.ArrayList;
+
+import static uk.gov.hmcts.sptribs.ciccase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+@Slf4j
+public class CicCreateCaseEvent implements CCDConfig<CaseData, State, UserRole> {
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        var defaultRoles = new ArrayList<UserRole>();
+        defaultRoles.add(UserRole.CITIZEN_CIC);
+        defaultRoles.add(UserRole.SUPER_USER);
+
+        var updatedRoles = defaultRoles;
+
+        configBuilder
+            .event("citizen-cic-create-dss-application")
+            .initialState(State.Draft)
+            .name("Create draft case (cic)")
+            .description("Apply for edge case (cic)")
+            .grant(CREATE_READ_UPDATE, updatedRoles.toArray(UserRole[]::new))
+            .aboutToSubmitCallback(this::aboutToSubmit)
+            .retries(120, 120);
+    }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> details,
+                                                                       CaseDetails<CaseData, State> beforeDetails) {
+        var caseData = details.getData();
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(caseData)
+            .state(State.Submitted)
+            .build();
+    }
+
+
+}

--- a/src/main/java/uk/gov/hmcts/sptribs/common/MappableObject.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/common/MappableObject.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.sptribs.common;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+public interface MappableObject {
+
+    default Map<String, Object> toMap(ObjectMapper mapper) {
+        return mapper.convertValue(this, new TypeReference<>() {
+        });
+    }
+}

--- a/src/main/java/uk/gov/hmcts/sptribs/document/model/EdgeCaseDocument.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/model/EdgeCaseDocument.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.sptribs.document.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+
+@Data
+@NoArgsConstructor
+@ToString
+public class EdgeCaseDocument {
+
+    @CCD(
+        label = "Document",
+        regex = ".doc,.docx,.pdf,.png,.xls,.xlsx,.jpg,.txt,.rtf,.rtf2,.gif,.mp3,.mp4"
+    )
+    private uk.gov.hmcts.ccd.sdk.type.Document documentLink;
+}

--- a/src/test/java/uk/gov/hmcts/sptribs/citizen/event/CicCreateCaseEventTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/citizen/event/CicCreateCaseEventTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.sptribs.citizen.event;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.SetMultimap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.Permission;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
+import uk.gov.hmcts.sptribs.ciccase.model.State;
+import uk.gov.hmcts.sptribs.ciccase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.ccd.sdk.api.Permission.C;
+import static uk.gov.hmcts.ccd.sdk.api.Permission.R;
+import static uk.gov.hmcts.ccd.sdk.api.Permission.U;
+import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.CITIZEN_CIC;
+import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.sptribs.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
+import static uk.gov.hmcts.sptribs.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class CicCreateCaseEventTest {
+
+    @InjectMocks
+    private CicCreateCaseEvent cicCreateCaseEvent;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilderAndSetPermissionOnlyForCitizenRole() {
+        final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
+
+        cicCreateCaseEvent.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains("citizen-cic-create-dss-application");
+
+        SetMultimap<UserRole, Permission> expectedRolesAndPermissions =
+            ImmutableSetMultimap.<UserRole, Permission>builder()
+                .put(CITIZEN_CIC, C)
+                .put(CITIZEN_CIC, R)
+                .put(CITIZEN_CIC, U)
+                .put(SUPER_USER, C)
+                .put(SUPER_USER, R)
+                .put(SUPER_USER, U)
+                .build();
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getGrants)
+            .containsExactly(expectedRolesAndPermissions);
+    }
+
+    @Test
+    void shouldChangeCaseStateWhenAboutToSubmit() {
+        // Given
+        CaseDetails<CaseData, State> details = new CaseDetails<>();
+        CaseDetails<CaseData, State> beforeDetails = new CaseDetails<>();
+
+        // When
+        AboutToStartOrSubmitResponse<CaseData, State> response = cicCreateCaseEvent.aboutToSubmit(
+            details,
+            beforeDetails
+        );
+
+        // Then
+        assertThat(response.getState()).isEqualTo(State.Submitted);
+    }
+}


### PR DESCRIPTION
### Change description ###

Add dss create event and case fields.  Deploying this to AAT should allow us to test whether new cases can be created via sptribs-case-api rather than sptribs-dss-backend.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ST-1078

