### PR TITLE
Use latest XUI secure doc store image in Release 2 branch

### DIFF
--- a/charts/sptribs-case-api/values.preview.template.yaml
+++ b/charts/sptribs-case-api/values.preview.template.yaml
@@ -353,7 +353,7 @@ xui-webapp:
   nodejs:
     imagePullPolicy: Always
     releaseNameOverride: ${SERVICE_NAME}-xui-webapp
-    image: hmctspublic.azurecr.io/xui/webapp:pr-3099
+    image: hmctspublic.azurecr.io/xui/webapp:pr-3099-0e8fc0e-20230621164233
     ingressHost: xui-${SERVICE_FQDN}
     devcpuRequests: 250m
     devmemoryRequests: 1024Mi


### PR DESCRIPTION
### Change description ###
Use latest XUI secure doc store image in Release 2 branch

### JIRA link (if applicable) ###
N/A

