### PR TITLE
add and fix/enable e2e tests for document management, contact parties and issue to respondent journeys

### DIFF
--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ContactPartiesTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ContactPartiesTests.java
@@ -15,8 +15,8 @@ import static uk.gov.hmcts.sptribs.e2e.enums.CaseState.CaseManagement;
 import static uk.gov.hmcts.sptribs.testutils.AssertionHelpers.textOptionsWithTimeout;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.clickButton;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.clickLink;
-import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCaseUrl;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCaseNumber;
+import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCaseUrl;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCheckBoxByLabel;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getTextBoxByLabel;
 

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ContactPartiesTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ContactPartiesTests.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.sptribs.e2e;
 import com.microsoft.playwright.Page;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import uk.gov.hmcts.sptribs.e2e.enums.Actions;
 
@@ -17,44 +16,48 @@ import static uk.gov.hmcts.sptribs.testutils.AssertionHelpers.textOptionsWithTim
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.clickButton;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.clickLink;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCaseUrl;
+import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCaseNumber;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCheckBoxByLabel;
+import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getTextBoxByLabel;
 
 public class ContactPartiesTests extends Base {
+    private final String documentCategory = "A - Notice of Appeal";
+    private final String documentDescription = "This is a test to upload document";
+    private final String documentName = "sample_file.pdf";
 
     @Order(1)
     @RepeatedIfExceptionsTest
     public void caseWorkerShouldBeAbleToContactParties() {
         Page page = getPage();
-        Login login = new Login(page);
-        login.loginAsCaseWorker();
-        Case newCase = new Case(page);
-        newCase.createCase(Representative);
-        newCase.buildCase();
+        Case newCase = createAndBuildCase(page, Representative);
+
         newCase.startNextStepAction(UploadDocuments);
         DocumentManagement docManagement = new DocumentManagement(page);
-        docManagement.uploadDocuments();
+        docManagement.uploadDocuments(documentCategory, documentDescription, documentName);
+
         newCase.startNextStepAction(ContactParties);
         completeContactPartiesJourney(page, ContactParties);
         Assertions.assertEquals(CaseManagement.label, newCase.getCaseStatus());
     }
 
     @Order(2)
-    @Disabled
+    @RepeatedIfExceptionsTest
     public void respondentShouldBeAbleToContactParties() {
         Page page = getPage();
-        Login login = new Login(page);
-        login.loginAsCaseWorker();
-        Case newCase = new Case(page);
-        final String caseNumber = newCase.createCase(Representative);
-        newCase.buildCase();
+        Case newCase = createAndBuildCase(page, Representative);
+        final String caseNumber = getCaseNumber(page);
+
         newCase.startNextStepAction(UploadDocuments);
         DocumentManagement docManagement = new DocumentManagement(page);
-        docManagement.uploadDocuments();
+        docManagement.uploadDocuments(documentCategory, documentDescription, documentName);
+
         clickLink(page, "Sign out");
+        Login login = new Login(page);
         login.loginAsStRespondentUser();
         page.navigate(getCaseUrl(caseNumber));
         assertThat(page.locator("ccd-markdown markdown h3").first())
             .hasText("Case number: " + caseNumber, textOptionsWithTimeout(60000));
+
         newCase.startNextStepAction(CicaContactParties);
         completeContactPartiesJourney(page, CicaContactParties);
         Assertions.assertEquals(CaseManagement.label, newCase.getCaseStatus());
@@ -85,7 +88,7 @@ public class ContactPartiesTests extends Base {
             && !page.isChecked("input[type='checkbox'][value='TribunalCIC']")) {
             getCheckBoxByLabel(page, "Tribunal").check();
         }
-        page.getByLabel("Message").fill("test123");
+        getTextBoxByLabel(page, "Message").fill("test123");
         clickButton(page, "Continue");
         assertThat(page.locator("h2")).hasText("Check your answers", textOptionsWithTimeout(30000));
         clickButton(page, "Save and continue");

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagement.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagement.java
@@ -17,9 +17,9 @@ public class DocumentManagement {
         this.page = page;
     }
 
-    public void uploadDocuments() {
+    public void uploadDocuments(String documentCategory, String documentDescription, String documentName) {
         assertThat(page.locator("h1")).hasText("Upload case documents", textOptionsWithTimeout(60000));
-        uploadDocument(page, "sample_file.pdf");
+        uploadDocument(page, documentCategory, documentDescription, documentName);
         clickButton(page, "Continue");
 
         assertThat(page.locator(".check-your-answers h2.heading-h2"))
@@ -34,11 +34,34 @@ public class DocumentManagement {
             .hasText("History", textOptionsWithTimeout(60000));
     }
 
-    private void uploadDocument(Page page, String file) {
+    public void amendDocument(String documentCategory, String documentDescription, String documentName) {
+        assertThat(page.locator("h1")).hasText("Select documents", textOptionsWithTimeout(60000));
+        String documentOptionSelector = "//select[@id='cicCaseAmendDocumentList']//option[contains(text(), '" + documentName + "')]";
+        String documentToSelect = page.locator(documentOptionSelector).textContent();
+        page.selectOption("#cicCaseAmendDocumentList", new SelectOption().setLabel(documentToSelect));
+        clickButton(page, "Continue");
+
+        assertThat(page.locator("h1")).hasText("Amend case documents", textOptionsWithTimeout(60000));
+        String amendedDocumentCategory = "A - Correspondence from the CICA";
+        page.selectOption("#cicCaseSelectedDocument_documentCategory", new SelectOption().setLabel(documentCategory));
+        String amendedDocumentDescription = "This is a test to amend document";
+        page.locator("#cicCaseSelectedDocument_documentEmailContent").fill(documentDescription);
+        clickButton(page, "Continue");
+
+        assertThat(page.locator(".check-your-answers h2.heading-h2"))
+            .hasText("Check your answers", textOptionsWithTimeout(60000));
+        clickButton(page, "Save and continue");
+
+        assertThat(page.locator("ccd-markdown markdown h1"))
+            .hasText("Document Updated", textOptionsWithTimeout(60000));
+        clickButton(page, "Close and Return to case details");
+    }
+
+    private void uploadDocument(Page page, String documentCategory, String documentDescription, String documentName) {
         clickButton(page, "Add new");
-        page.selectOption("#newCaseworkerCICDocument_0_documentCategory", new SelectOption().setLabel("A - Notice of Appeal"));
-        page.locator("#newCaseworkerCICDocument_0_documentEmailContent").fill("This is a test document");
-        page.setInputFiles("input[type='file']", Paths.get("src/e2eTests/java/uk/gov/hmcts/sptribs/testutils/files/" + file));
+        page.selectOption("#newCaseworkerCICDocument_0_documentCategory", new SelectOption().setLabel(documentCategory));
+        page.locator("#newCaseworkerCICDocument_0_documentEmailContent").fill(documentDescription);
+        page.setInputFiles("input[type='file']", Paths.get("src/e2eTests/java/uk/gov/hmcts/sptribs/testutils/files/" + documentName));
         page.waitForFunction("selector => document.querySelector(selector).disabled === true",
             "button[aria-label='Cancel upload']", functionOptionsWithTimeout(15000));
     }

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagementTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagementTests.java
@@ -3,29 +3,57 @@ package uk.gov.hmcts.sptribs.e2e;
 import com.microsoft.playwright.Page;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import org.junit.jupiter.api.Assertions;
-import uk.gov.hmcts.sptribs.testutils.PageHelpers;
+import org.junit.jupiter.api.Order;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static uk.gov.hmcts.sptribs.e2e.enums.Actions.AmendDocuments;
 import static uk.gov.hmcts.sptribs.e2e.enums.Actions.UploadDocuments;
 import static uk.gov.hmcts.sptribs.e2e.enums.CasePartyContactPreference.Representative;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getTabByText;
+import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getValueFromTableFor;
 
 public class DocumentManagementTests extends Base {
 
+    private final String documentCategory = "A - Notice of Appeal";
+    private final String documentDescription = "This is a test to upload document";
+    private final String documentName = "sample_file.pdf";
+
+    @Order(1)
     @RepeatedIfExceptionsTest
     public void caseWorkerShouldBeAbleToUploadDocuments() {
         Page page = getPage();
         Case newCase = createAndBuildCase(page, Representative);
+
         newCase.startNextStepAction(UploadDocuments);
         DocumentManagement docManagement = new DocumentManagement(page);
-        docManagement.uploadDocuments();
+        docManagement.uploadDocuments(documentCategory, documentDescription, documentName);
+
         getTabByText(page, "Case Documents").click();
         assertThat(page.locator("h4").first()).hasText("Case Documents");
-        String hearingStatus = PageHelpers.getValueFromTableFor(page, "Document Category");
-        Assertions.assertEquals("A - Notice of Appeal", hearingStatus);
-        String hearingType = PageHelpers.getValueFromTableFor(page, "Description");
-        Assertions.assertEquals("This is a test document", hearingType);
-        String hearingFormat = PageHelpers.getValueFromTableFor(page, "File");
-        Assertions.assertEquals("sample_file.pdf", hearingFormat);
+        Assertions.assertEquals(documentCategory, getValueFromTableFor(page, "Document Category"));
+        Assertions.assertEquals(documentDescription, getValueFromTableFor(page, "Description"));
+        Assertions.assertEquals(documentName, getValueFromTableFor(page, "File"));
+    }
+
+    @Order(2)
+    @RepeatedIfExceptionsTest
+    public void seniorCaseWorkerShouldBeAbleToAmendDocuments() {
+        Page page = getPage();
+        Case newCase = createAndBuildCase(page, Representative);
+
+        newCase.startNextStepAction(UploadDocuments);
+        DocumentManagement docManagement = new DocumentManagement(page);
+        docManagement.uploadDocuments(documentCategory, documentDescription, documentName);
+
+        newCase.startNextStepAction(AmendDocuments);
+        String amendedDocumentCategory = "A - Correspondence from the CICA";
+        String amendedDocumentDescription = "This is a test to amend document";
+        docManagement.amendDocument(amendedDocumentCategory, amendedDocumentDescription, documentName);
+
+        getTabByText(page, "Case Documents").click();
+        assertThat(page.locator("h4").first()).hasText("Case Documents");
+        Assertions.assertEquals(amendedDocumentCategory, getValueFromTableFor(page, "Document Category"));
+        Assertions.assertEquals(amendedDocumentDescription, getValueFromTableFor(page, "Description"));
+        Assertions.assertEquals(documentName, getValueFromTableFor(page, "File"));
     }
 }

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueToRespondentTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueToRespondentTests.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.sptribs.e2e;
 
 import com.microsoft.playwright.Page;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static uk.gov.hmcts.sptribs.e2e.enums.Actions.IssueCaseToRespondent;
@@ -15,25 +15,27 @@ import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCheckBoxByLabel;
 
 public class IssueToRespondentTests extends Base {
 
-    @Disabled
+    @RepeatedIfExceptionsTest
     public void caseWorkerShouldAbleToManageIssueToRespondent() {
+        String documentCategory = "A - Notice of Appeal";
+        String documentDescription = "uploading document for issue to respondent journey";
+        String documentName = "sample_file.pdf";
+
         Page page = getPage();
-        Login login = new Login(page);
-        login.loginAsCaseWorker();
-        Case newCase = new Case(page);
-        newCase.createCase(Representative);
-        newCase.buildCase();
+        Case newCase = createAndBuildCase(page, Representative);
+
         newCase.startNextStepAction(UploadDocuments);
         DocumentManagement docManagement = new DocumentManagement(page);
-        docManagement.uploadDocuments();
+        docManagement.uploadDocuments(documentCategory, documentDescription, documentName);
+
         newCase.startNextStepAction(IssueCaseToRespondent);
         assertThat(page.locator("h1")).hasText("Select additional documents", textOptionsWithTimeout(60000));
         getCheckBoxByLabel(page, "sample_file.pdf").check();
         clickButton(page, "Continue");
         assertThat(page.locator("h1")).hasText("Notify other parties", textOptionsWithTimeout(60000));
-        page.getByLabel("Subject").check();
-        page.getByLabel("Representative").check();
-        page.getByLabel("Respondent").check();
+        getCheckBoxByLabel(page, "Subject").check();
+        getCheckBoxByLabel(page, "Representative").check();
+        getCheckBoxByLabel(page, "Respondent").check();
         clickButton(page, "Continue");
         assertThat(page.locator("h2.heading-h2")).hasText("Check your answers", textOptionsWithTimeout(30000));
         clickButton(page, "Save and continue");

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Login.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Login.java
@@ -86,6 +86,14 @@ public class Login {
         loginAs(getenv("LEGAL_OFFICER"));
     }
 
+    public void loginAsSeniorCaseWorker() {
+        loginAs(getenv("SENIOR_LEGAL_OFFICER"));
+    }
+
+    public void loginAsSeniorJudge() {
+        loginAs(getenv("SENIOR_JUDGE"));
+    }
+
     public void loginAsHearingCentreTL() {
         loginAs(getenv("HEARING_CENTRAL_TEAM_LEAD"));
     }

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/enums/Actions.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/enums/Actions.java
@@ -31,7 +31,9 @@ public enum Actions {
     TestChangeState("Test change state"),
     ReferCaseToJudge("Refer case to judge"),
     ReferCaseToLegalOfficer("Refer case to legal officer"),
-    UploadDocuments("Document management: Upload");
+    UploadDocuments("Document management: Upload"),
+    AmendDocuments("Document management: Amend"),
+    RemoveDocuments("Document management: Remove");
 
     public final String label;
 

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/testutils/PageHelpers.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/testutils/PageHelpers.java
@@ -81,4 +81,10 @@ public class PageHelpers {
     public static void clickLink(Page page, String linkText) {
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(linkText)).click();
     }
+
+    public static String getCaseNumber(Page page) {
+        String caseNumberHeading = page.locator("ccd-markdown markdown h3").textContent();
+        return page.locator("ccd-markdown markdown h3")
+            .textContent().substring(caseNumberHeading.lastIndexOf(" ")).trim();
+    }
 }


### PR DESCRIPTION
### Description ###

This PR:

1. adds E2E test for document management - amend document journey
2. fixes and enables contact parties E2E test
3. fixes and enables issue to respondent E2E test

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ST-1579

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)

