### PR TITLE
Add e2e test for remove docs event

### DIFF
--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagement.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagement.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.sptribs.e2e;
 
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.SelectOption;
+import com.microsoft.playwright.options.WaitForSelectorState;
+import org.junit.jupiter.api.Assertions;
 
 import java.nio.file.Paths;
 
@@ -9,6 +11,7 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 import static uk.gov.hmcts.sptribs.testutils.AssertionHelpers.textOptionsWithTimeout;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.clickButton;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.functionOptionsWithTimeout;
+import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getValueFromTableFor;
 
 public class DocumentManagement {
     private final Page page;
@@ -55,6 +58,35 @@ public class DocumentManagement {
         assertThat(page.locator("ccd-markdown markdown h1"))
             .hasText("Document Updated", textOptionsWithTimeout(60000));
         clickButton(page, "Close and Return to case details");
+    }
+
+    public void removeDocument(String documentCategory, String documentDescription, String documentName) {
+        assertThat(page.locator("h1")).hasText("Show case documents", textOptionsWithTimeout(60000));
+        String documentRemoveSelector = "//div[@class='form-group'][.//div//a[contains(text(), '" + documentName + "')]]//button[text()='Remove']";
+
+        page.locator(documentRemoveSelector).click();
+        page.locator("ccd-remove-dialog button[title='Remove']").click();
+        page.waitForSelector(documentRemoveSelector, new Page.WaitForSelectorOptions().setState(WaitForSelectorState.HIDDEN));
+        clickButton(page, "Continue");
+
+        assertThat(page.locator("h1")).hasText("Removed documents", textOptionsWithTimeout(60000));
+        String displayedDocumentCategory =
+            page.locator("//ccd-field-read-label[.//dt[text()='Document Category']]//ccd-read-fixed-list-field/span").textContent().trim();
+        String displayedDescription =
+            page.locator("//ccd-field-read-label[.//dt[text()='Description']]//ccd-read-text-area-field/span").textContent().trim();
+        String displayedFileName =
+            page.locator("//ccd-field-read-label[.//dt[text()='File']]//ccd-read-document-field/a").textContent().trim();
+        Assertions.assertEquals(documentCategory, displayedDocumentCategory);
+        Assertions.assertEquals(documentDescription, displayedDescription);
+        Assertions.assertEquals(documentName, displayedFileName);
+        clickButton(page, "Submit");
+
+        assertThat(page.locator("ccd-markdown markdown h1"))
+            .hasText("Case Updated", textOptionsWithTimeout(60000));
+        clickButton(page, "Close and Return to case details");
+
+        assertThat(page.locator("h2.heading-h2").first())
+            .hasText("History", textOptionsWithTimeout(60000));
     }
 
     private void uploadDocument(Page page, String documentCategory, String documentDescription, String documentName) {

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagement.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagement.java
@@ -11,7 +11,6 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 import static uk.gov.hmcts.sptribs.testutils.AssertionHelpers.textOptionsWithTimeout;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.clickButton;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.functionOptionsWithTimeout;
-import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getValueFromTableFor;
 
 public class DocumentManagement {
     private final Page page;
@@ -62,7 +61,8 @@ public class DocumentManagement {
 
     public void removeDocument(String documentCategory, String documentDescription, String documentName) {
         assertThat(page.locator("h1")).hasText("Show case documents", textOptionsWithTimeout(60000));
-        String documentRemoveSelector = "//div[@class='form-group'][.//div//a[contains(text(), '" + documentName + "')]]//button[text()='Remove']";
+        String documentRemoveSelector = "//div[@class='form-group'][.//div//a[contains(text(), '"
+            + documentName + "')]]//button[text()='Remove']";
 
         page.locator(documentRemoveSelector).click();
         page.locator("ccd-remove-dialog button[title='Remove']").click();

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagementTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagementTests.java
@@ -87,6 +87,6 @@ public class DocumentManagementTests extends Base {
 
         getTabByText(page, "Case Documents").click();
         assertThat(page.locator("h4").first()).hasText("Case Documents");
-        assertThat(page.locator("//a[contains(text(), 'sample_file.pdf')]")).isHidden();
+        assertThat(page.locator("//a[contains(text(), '" + documentName + "')]")).isHidden();
     }
 }


### PR DESCRIPTION
### Description ###

This PR adds E2E test for `Document management: Remove` event journey

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ST-1639

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)

