### PR TITLE
SNI-4966

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerSendOrderFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerSendOrderFT.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.sptribs.caseworker;
+
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import uk.gov.hmcts.sptribs.testutil.FunctionalTestSuite;
+
+import java.util.Map;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.OK;
+import static uk.gov.hmcts.sptribs.caseworker.util.EventConstants.CASEWORKER_SEND_ORDER;
+import static uk.gov.hmcts.sptribs.testutil.CaseDataUtil.caseData;
+import static uk.gov.hmcts.sptribs.testutil.TestConstants.ABOUT_TO_SUBMIT_URL;
+import static uk.gov.hmcts.sptribs.testutil.TestResourceUtil.expectedResponse;
+
+@SpringBootTest
+public class CaseworkerSendOrderFT extends FunctionalTestSuite {
+
+    private static final String REQUEST = "classpath:request/casedata/ccd-callback-casedata-send-order-about-to-start.json";
+    private static final String RESPONSE = "classpath:responses/response-caseworker-send-order-about-to-submit.json";
+
+    @Test
+    public void shouldRetainLastSelectedOrderDataWhenAboutToSubmitCallbackIsTriggered() throws Exception {
+        final Map<String, Object> caseData = caseData(REQUEST);
+
+        final Response response = triggerCallback(caseData, CASEWORKER_SEND_ORDER, ABOUT_TO_SUBMIT_URL);
+        assertThat(response.getStatusCode()).isEqualTo(OK.value());
+
+        assertThatJson(response.asString())
+            .when(IGNORING_EXTRA_FIELDS)
+            .isEqualTo(json(expectedResponse(RESPONSE)));
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerSendOrderFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerSendOrderFT.java
@@ -25,7 +25,7 @@ public class CaseworkerSendOrderFT extends FunctionalTestSuite {
     private static final String RESPONSE = "classpath:responses/response-caseworker-send-order-about-to-submit.json";
 
     @Test
-    public void shouldRetainLastSelectedOrderDataWhenAboutToSubmitCallbackIsTriggered() throws Exception {
+    public void shouldRetainSelectedOrderDataWhenAboutToSubmitCallbackIsTriggered() throws Exception {
         final Map<String, Object> caseData = caseData(REQUEST);
 
         final Response response = triggerCallback(caseData, CASEWORKER_SEND_ORDER, ABOUT_TO_SUBMIT_URL);

--- a/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerSendOrderFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerSendOrderFT.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.OK;
@@ -32,6 +33,7 @@ public class CaseworkerSendOrderFT extends FunctionalTestSuite {
 
         assertThatJson(response.asString())
             .when(IGNORING_EXTRA_FIELDS)
+            .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(json(expectedResponse(RESPONSE)));
     }
 }

--- a/src/functionalTest/resources/request/casedata/ccd-callback-casedata-send-order-about-to-start.json
+++ b/src/functionalTest/resources/request/casedata/ccd-callback-casedata-send-order-about-to-start.json
@@ -33,7 +33,7 @@
   "securityClass": "PUBLIC",
   "caseBundles": [],
   "cicCaseOrderDueDates": [],
-  "cicCaseLastSelectedOrder": {
+  "cicCaseSelectedOrder": {
     "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932",
     "document_filename": "test.pdf",
     "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932/binary",

--- a/src/functionalTest/resources/request/casedata/ccd-callback-casedata-send-order-about-to-start.json
+++ b/src/functionalTest/resources/request/casedata/ccd-callback-casedata-send-order-about-to-start.json
@@ -1,0 +1,145 @@
+{
+  "allCaseworkerCICDocument": [
+    {
+      "id": "c340d45a-7909-466b-bee9-ec07742cc59c",
+      "value": {
+        "documentCategory": "Mental Health records",
+        "documentEmailContent": "A test doc",
+        "documentLink": {
+          "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/5dabdd89-42e4-4294-8d67-a7aae560e6b6",
+          "document_filename": "Test-Letter-V2 3.pdf",
+          "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/5dabdd89-42e4-4294-8d67-a7aae560e6b6/binary",
+          "category_id": "C"
+        }
+      }
+    },
+    {
+      "id": "051e0fee-5229-4574-bdd0-c27ae8f91bed",
+      "value": {
+        "documentCategory": "Application for review",
+        "documentEmailContent": "test",
+        "documentLink": {
+          "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/328c674f-59c3-418a-b76b-78f2cc52d21a",
+          "document_filename": "sample4.m4a",
+          "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/328c674f-59c3-418a-b76b-78f2cc52d21a/binary",
+          "category_id": "A"
+        }
+      }
+    }
+  ],
+  "newCaseworkerCICDocument": [],
+  "editCicaCaseDetails": {},
+  "contactParties": {},
+  "securityClass": "PUBLIC",
+  "caseBundles": [],
+  "cicCaseOrderDueDates": [],
+  "cicCaseLastSelectedOrder": {
+    "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932",
+    "document_filename": "test.pdf",
+    "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932/binary",
+    "category_id": "TD"
+  },
+  "cicCaseOrderList": [
+    {
+      "id": "1",
+      "value": {
+        "dueDateList": [],
+        "uploadedFile": [
+          {
+            "id": "79caf004-20e9-4837-abb7-8c22282bf9b5",
+            "value": {
+              "documentEmailContent": "Test",
+              "documentLink": {
+                "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932",
+                "document_filename": "test.pdf",
+                "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932/binary",
+                "category_id": "TD"
+              }
+            }
+          }
+        ],
+        "parties": "Representative",
+        "orderSentDate": "2023-11-23"
+      }
+    }
+  ],
+  "cicCaseOrderDocumentList": [],
+  "cicCaseCaseCategory": "Assessment",
+  "cicCaseCaseSubcategory": "Fatal",
+  "cicCaseCaseReceivedDate": "2023-01-01",
+  "cicCasePartiesCIC": [
+    "SubjectCIC",
+    "RepresentativeCIC",
+    "ApplicantCIC"
+  ],
+  "cicCaseSubjectCIC": [],
+  "cicCaseApplicantCIC": [
+    "ApplicantCIC"
+  ],
+  "cicCaseRepresentativeCIC": [
+    "RepresentativeCIC"
+  ],
+  "cicCaseNotifyPartyApplicant": [],
+  "cicCaseNotifyPartySubject": [],
+  "cicCaseNotifyPartyRepresentative": [
+    "RepresentativeCIC"
+  ],
+  "cicCaseNotifyPartyRespondent": [],
+  "cicCaseRespondentName": "Appeals team",
+  "cicCaseRespondentOrganisation": "CICA",
+  "cicCaseRespondentEmail": "appeals.team@cica.gov.uk",
+  "cicCaseFullName": "Test Tester",
+  "cicCaseAddress": {
+    "AddressLine1": "1 Rse Way",
+    "AddressLine2": "",
+    "AddressLine3": "",
+    "PostTown": "London",
+    "County": "",
+    "PostCode": "SW11 1PD",
+    "Country": "United Kingdom"
+  },
+  "cicCaseEmail": "st-test1@mailinator.com",
+  "cicCaseDateOfBirth": "1990-01-01",
+  "cicCaseContactPreferenceType": "Email",
+  "cicCaseSchemeCic": "Preference",
+  "cicCaseRegionCIC": "Midlands",
+  "cicCaseApplicantFullName": "Test Test",
+  "cicCaseApplicantAddress": {
+    "AddressLine1": "1 Rse Way",
+    "AddressLine2": "",
+    "AddressLine3": "",
+    "PostTown": "London",
+    "County": "",
+    "PostCode": "SW11 1PD",
+    "Country": "United Kingdom"
+  },
+  "cicCaseApplicantPhoneNumber": "0764646346356",
+  "cicCaseApplicantDateOfBirth": "1980-01-01",
+  "cicCaseApplicantContactDetailsPreference": "Post",
+  "cicCaseRepresentativeFullName": "Resp Respondernt",
+  "cicCaseRepresentativeAddress": {
+    "AddressLine1": "1 Rse Way",
+    "AddressLine2": "",
+    "AddressLine3": "",
+    "PostTown": "London",
+    "County": "",
+    "PostCode": "SW11 1PD",
+    "Country": "United Kingdom"
+  },
+  "cicCaseRepresentativePhoneNumber": "0745435345356",
+  "cicCaseRepresentativeContactDetailsPreference": "Post",
+  "cicCaseIsRepresentativeQualified": "No",
+  "cicCaseFormReceivedInTime": "Yes",
+  "cicCaseClaimLinkedToCic": "No",
+  "cicCaseCompensationClaimLinkCIC": "No",
+  "cicCaseIsRepresentativePresent": "Yes",
+  "cicCaseApplicantDocumentsUploaded": [],
+  "cicCaseReinstateDocuments": [],
+  "cicCaseDecisionDocumentList": [],
+  "cicCaseRemovedDocumentList": [],
+  "cicCaseFinalDecisionDocumentList": [],
+  "stayIsCaseStayed": "No",
+  "hearingSummaryExists": "YES",
+  "hearingList": [],
+  "hyphenatedCaseRef": "1699-9545-8542-9659"
+}

--- a/src/functionalTest/resources/responses/response-caseworker-send-order-about-to-submit.json
+++ b/src/functionalTest/resources/responses/response-caseworker-send-order-about-to-submit.json
@@ -40,7 +40,7 @@
         "value": {
           "dueDateList": [],
           "parties": "Representative",
-          "orderSentDate": "2023-11-23"
+          "orderSentDate": "${json-unit.any-string}"
         }
       },
       {
@@ -62,14 +62,14 @@
             }
           ],
           "parties": "Representative",
-          "orderSentDate": "2023-11-23"
+          "orderSentDate": "${json-unit.any-string}"
         }
       }
     ],
     "cicCaseOrderDocumentList": [],
     "cicCaseCaseCategory": "Assessment",
     "cicCaseCaseSubcategory": "Fatal",
-    "cicCaseCaseReceivedDate": "2023-01-01",
+    "cicCaseCaseReceivedDate": "${json-unit.any-string}",
     "cicCasePartiesCIC": [
       "ApplicantCIC",
       "RepresentativeCIC",

--- a/src/functionalTest/resources/responses/response-caseworker-send-order-about-to-submit.json
+++ b/src/functionalTest/resources/responses/response-caseworker-send-order-about-to-submit.json
@@ -149,7 +149,7 @@
     "closedDayCount": "",
     "firstHearingDate": "",
     "dataVersion": 0,
-    "cicCaseLastSelectedOrder": {
+    "cicCaseSelectedOrder": {
       "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932",
       "document_filename": "test.pdf",
       "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932/binary",

--- a/src/functionalTest/resources/responses/response-caseworker-send-order-about-to-submit.json
+++ b/src/functionalTest/resources/responses/response-caseworker-send-order-about-to-submit.json
@@ -1,0 +1,159 @@
+{
+  "data": {
+    "allCaseworkerCICDocument": [
+      {
+        "id": "${json-unit.any-string}",
+        "value": {
+          "documentCategory": "Mental Health records",
+          "documentEmailContent": "A test doc",
+          "documentLink": {
+            "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/5dabdd89-42e4-4294-8d67-a7aae560e6b6",
+            "document_filename": "Test-Letter-V2 3.pdf",
+            "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/5dabdd89-42e4-4294-8d67-a7aae560e6b6/binary",
+            "category_id": "C"
+          }
+        }
+      },
+      {
+        "id": "${json-unit.any-string}",
+        "value": {
+          "documentCategory": "Application for review",
+          "documentEmailContent": "test",
+          "documentLink": {
+            "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/328c674f-59c3-418a-b76b-78f2cc52d21a",
+            "document_filename": "sample4.m4a",
+            "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/328c674f-59c3-418a-b76b-78f2cc52d21a/binary",
+            "category_id": "A"
+          }
+        }
+      }
+    ],
+    "newCaseworkerCICDocument": [],
+    "editCicaCaseDetails": {},
+    "contactParties": {},
+    "securityClass": "PUBLIC",
+    "caseBundles": [],
+    "cicCaseOrderDueDates": [],
+    "cicCaseOrderList": [
+      {
+        "id": "1",
+        "value": {
+          "dueDateList": [],
+          "parties": "Representative",
+          "orderSentDate": "2023-11-23"
+        }
+      },
+      {
+        "id": "2",
+        "value": {
+          "dueDateList": [],
+          "uploadedFile": [
+            {
+              "id": "${json-unit.any-string}",
+              "value": {
+                "documentEmailContent": "Test",
+                "documentLink": {
+                  "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932",
+                  "document_filename": "test.pdf",
+                  "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932/binary",
+                  "category_id": "TD"
+                }
+              }
+            }
+          ],
+          "parties": "Representative",
+          "orderSentDate": "2023-11-23"
+        }
+      }
+    ],
+    "cicCaseOrderDocumentList": [],
+    "cicCaseCaseCategory": "Assessment",
+    "cicCaseCaseSubcategory": "Fatal",
+    "cicCaseCaseReceivedDate": "2023-01-01",
+    "cicCasePartiesCIC": [
+      "ApplicantCIC",
+      "RepresentativeCIC",
+      "SubjectCIC"
+    ],
+    "cicCaseSubjectCIC": [],
+    "cicCaseApplicantCIC": [
+      "ApplicantCIC"
+    ],
+    "cicCaseRepresentativeCIC": [
+      "RepresentativeCIC"
+    ],
+    "cicCaseNotifyPartyApplicant": [],
+    "cicCaseNotifyPartySubject": [],
+    "cicCaseNotifyPartyRepresentative": [
+      "RepresentativeCIC"
+    ],
+    "cicCaseNotifyPartyRespondent": [],
+    "cicCaseRespondentName": "Appeals team",
+    "cicCaseRespondentOrganisation": "CICA",
+    "cicCaseRespondentEmail": "appeals.team@cica.gov.uk",
+    "cicCaseFullName": "Test Tester",
+    "cicCaseAddress": {
+      "AddressLine1": "1 Rse Way",
+      "AddressLine2": "",
+      "AddressLine3": "",
+      "PostTown": "London",
+      "County": "",
+      "PostCode": "SW11 1PD",
+      "Country": "United Kingdom"
+    },
+    "cicCaseEmail": "st-test1@mailinator.com",
+    "cicCaseDateOfBirth": "1990-01-01",
+    "cicCaseContactPreferenceType": "Email",
+    "cicCaseSchemeCic": "Preference",
+    "cicCaseRegionCIC": "Midlands",
+    "cicCaseApplicantFullName": "Test Test",
+    "cicCaseApplicantAddress": {
+      "AddressLine1": "1 Rse Way",
+      "AddressLine2": "",
+      "AddressLine3": "",
+      "PostTown": "London",
+      "County": "",
+      "PostCode": "SW11 1PD",
+      "Country": "United Kingdom"
+    },
+    "cicCaseApplicantPhoneNumber": "0764646346356",
+    "cicCaseApplicantDateOfBirth": "1980-01-01",
+    "cicCaseApplicantContactDetailsPreference": "Post",
+    "cicCaseRepresentativeFullName": "Resp Respondernt",
+    "cicCaseRepresentativeAddress": {
+      "AddressLine1": "1 Rse Way",
+      "AddressLine2": "",
+      "AddressLine3": "",
+      "PostTown": "London",
+      "County": "",
+      "PostCode": "SW11 1PD",
+      "Country": "United Kingdom"
+    },
+    "cicCaseRepresentativePhoneNumber": "0745435345356",
+    "cicCaseRepresentativeContactDetailsPreference": "Post",
+    "cicCaseIsRepresentativeQualified": "No",
+    "cicCaseFormReceivedInTime": "Yes",
+    "cicCaseClaimLinkedToCic": "No",
+    "cicCaseCompensationClaimLinkCIC": "No",
+    "cicCaseIsRepresentativePresent": "Yes",
+    "cicCaseApplicantDocumentsUploaded": [],
+    "cicCaseReinstateDocuments": [],
+    "cicCaseDecisionDocumentList": [],
+    "cicCaseRemovedDocumentList": [],
+    "cicCaseFinalDecisionDocumentList": [],
+    "cicCaseFirstDueDate": "",
+    "stayIsCaseStayed": "No",
+    "hearingSummaryExists": "YES",
+    "hearingList": [],
+    "hyphenatedCaseRef": "1699-9545-8542-9659",
+    "closedDayCount": "",
+    "firstHearingDate": "",
+    "dataVersion": 0,
+    "cicCaseLastSelectedOrder": {
+      "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932",
+      "document_filename": "test.pdf",
+      "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c42d2333-b4c6-4065-a528-3cff9a0cd932/binary",
+      "category_id": "TD"
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerSendOrder.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerSendOrder.java
@@ -127,7 +127,7 @@ public class CaseworkerSendOrder implements CCDConfig<CaseData, State, UserRole>
             }
         }
 
-        updateLastSelectedOrder(caseData.getCicCase(), order);
+        updateSelectedOrder(caseData.getCicCase(), order);
         updateCicCaseOrderList(caseData, order);
 
         caseData.getCicCase().setOrderIssuingType(null);
@@ -216,12 +216,12 @@ public class CaseworkerSendOrder implements CCDConfig<CaseData, State, UserRole>
         }
     }
 
-    private void updateLastSelectedOrder(CicCase cicCase, Order order) {
+    private void updateSelectedOrder(CicCase cicCase, Order order) {
         if (order.getDraftOrder() != null) {
-            cicCase.setLastSelectedOrder(order.getDraftOrder().getTemplateGeneratedDocument());
+            cicCase.setSelectedOrder(order.getDraftOrder().getTemplateGeneratedDocument());
         } else if (order.getUploadedFile() != null && !CollectionUtils.isEmpty(order.getUploadedFile())) {
             updateCategoryToDocument(order.getUploadedFile(), DocumentType.TRIBUNAL_DIRECTION.getCategory());
-            cicCase.setLastSelectedOrder(order.getUploadedFile().get(0).getValue().getDocumentLink());
+            cicCase.setSelectedOrder(order.getUploadedFile().get(0).getValue().getDocumentLink());
         }
     }
 
@@ -243,6 +243,6 @@ public class CaseworkerSendOrder implements CCDConfig<CaseData, State, UserRole>
         }
 
         //Once Notification is sent, nullify the last selected order
-        caseData.getCicCase().setLastSelectedOrder(null);
+        caseData.getCicCase().setSelectedOrder(null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/CicCase.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/CicCase.java
@@ -202,7 +202,6 @@ public class CicCase {
     @CCD(
         access = {DefaultAccess.class, CaseworkerWithCAAAccess.class}
     )
-    @JsonIgnore
     private Document lastSelectedOrder;
 
     @CCD(
@@ -791,6 +790,5 @@ public class CicCase {
         applicantAddress = new AddressGlobalUK();
         applicantPhoneNumber = "";
         applicantEmailAddress = "";
-
     }
 }

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/CicCase.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/CicCase.java
@@ -202,7 +202,7 @@ public class CicCase {
     @CCD(
         access = {DefaultAccess.class, CaseworkerWithCAAAccess.class}
     )
-    private Document lastSelectedOrder;
+    private Document selectedOrder;
 
     @CCD(
         label = "Should a reminder notification be sent? You can only send a reminder for the earliest due date stated on this order",

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/RetiredFields.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/RetiredFields.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.elasticsearch.common.TriConsumer;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.sptribs.caseworker.model.HearingCancellationReason;
 import uk.gov.hmcts.sptribs.caseworker.model.PostponeReason;
@@ -24,6 +25,11 @@ public class RetiredFields {
     @CCD(label = "Case data version", access = {DefaultAccess.class, CaseworkerWithCAAAccess.class})
     private int dataVersion;
 
+    @CCD(
+        access = {DefaultAccess.class, CaseworkerWithCAAAccess.class}
+    )
+    @JsonIgnore
+    private Document cicCaseLastSelectedOrder;
 
     @CCD(access = {DefaultAccess.class, CaseworkerWithCAAAccess.class})
     private List<ListValue<Bundle>> cicBundles;

--- a/src/main/java/uk/gov/hmcts/sptribs/common/notification/NewOrderIssuedNotification.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/common/notification/NewOrderIssuedNotification.java
@@ -117,8 +117,8 @@ public class NewOrderIssuedNotification implements PartiesNotification {
     private Map<String, String> getUploadedDocumentIds(CaseData caseData) {
         CicCase cicCase = caseData.getCicCase();
         Map<String, String> uploadedDocuments = new HashMap<>();
-        if (null != cicCase.getLastSelectedOrder()) {
-            uploadedDocuments.put(TRIBUNAL_ORDER, StringUtils.substringAfterLast(cicCase.getLastSelectedOrder().getUrl(), "/"));
+        if (null != cicCase.getSelectedOrder()) {
+            uploadedDocuments.put(TRIBUNAL_ORDER, StringUtils.substringAfterLast(cicCase.getSelectedOrder().getUrl(), "/"));
 
         }
 

--- a/src/test/java/uk/gov/hmcts/sptribs/common/notification/NewOrderIssuedNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/common/notification/NewOrderIssuedNotificationTest.java
@@ -46,7 +46,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -68,7 +68,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -91,7 +91,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -132,7 +132,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -154,7 +154,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -177,7 +177,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -201,7 +201,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -242,7 +242,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -264,7 +264,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))
@@ -287,7 +287,7 @@ public class NewOrderIssuedNotificationTest {
 
         final UUID uuid = UUID.randomUUID();
         final Document document = Document.builder().binaryUrl("http://url/" + uuid).url("http://url/" + uuid).build();
-        data.getCicCase().setLastSelectedOrder(document);
+        data.getCicCase().setSelectedOrder(document);
 
         //When
         when(notificationHelper.buildEmailNotificationRequest(any(), anyBoolean(), anyMap(), anyMap(), any(TemplateName.class)))


### PR DESCRIPTION
### Change description ###
- Retire last selected order field that has been enabled a disabled with JsonIgnore a few times causing ES issues
- Replace last selected order with a new field called selected order

NOTE: no migration required as field is assigned for the purpose of attaching the selected order to the document
Testing carried out with an old case locally (see below screenshot)

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SNI-4966

<img width="1440" alt="Screenshot 2023-11-23 at 18 31 29" src="https://github.com/hmcts/sptribs-case-api/assets/20407957/318a6976-68b7-4751-8ccb-2cd00779f2cc">
