### PR TITLE
Update hearing tests with correct judicial data

### DIFF
--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Hearing.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Hearing.java
@@ -203,7 +203,7 @@ public class Hearing {
         Assertions.assertEquals(AwaitingHearing.label, newCase.getCaseStatus());
     }
 
-    public void createHearingSummary() {
+    public void createHearingSummary(String judge, String panelMember) {
         Case newCase = new Case(page);
         newCase.startNextStepAction(CreateSummary);
 
@@ -225,10 +225,10 @@ public class Hearing {
         // Fill Hearing attendees form
         assertThat(page.locator("h1"))
             .hasText("Hearing attendees", textOptionsWithTimeout(30000));
-        page.selectOption("#judge", new SelectOption().setLabel("Chetan Lad"));
+        page.selectOption("#judge", new SelectOption().setLabel(judge));
         getRadioButtonByLabel(page, "Yes").click();
         clickButton(page, "Add new");
-        page.selectOption("#memberList_0_name", new SelectOption().setLabel("Joe Bloggs"));
+        page.selectOption("#memberList_0_name", new SelectOption().setLabel(panelMember));
         getRadioButtonByLabel(page, "Full member").click();
         PageHelpers.clickButton(page, "Continue");
 
@@ -270,7 +270,7 @@ public class Hearing {
         Assertions.assertEquals(AwaitingOutcome.label, newCase.getCaseStatus());
     }
 
-    public void editHearingSummary() {
+    public void editHearingSummary(String judge, String panelMember) {
         Case newCase = new Case(page);
         newCase.startNextStepAction(EditSummary);
 
@@ -297,9 +297,9 @@ public class Hearing {
         // Fill Hearing attendees form
         assertThat(page.locator("h1"))
             .hasText("Hearing attendees", textOptionsWithTimeout(30000));
-        page.selectOption("#judge", new SelectOption().setLabel("Chetan Lad"));
+        page.selectOption("#judge", new SelectOption().setLabel(judge));
         getRadioButtonByLabel(page, "Yes").click();
-        page.selectOption("#memberList_0_name", new SelectOption().setLabel("Joe Bloggs"));
+        page.selectOption("#memberList_0_name", new SelectOption().setLabel(panelMember));
         getRadioButtonByLabel(page, "Observer").click();
         PageHelpers.clickButton(page, "Continue");
 

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/HearingJourneyTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/HearingJourneyTests.java
@@ -14,6 +14,9 @@ import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getTabByText;
 
 public class HearingJourneyTests extends Base {
 
+    private final String judge = "Carys Cotton";
+    private final String panelMember = "Dr Aaron Owens";
+
     @RepeatedIfExceptionsTest
     public void caseWorkerShouldBeAbleToEditListingAndViewDetailsInHearingTab() {
         Page page = getPage();
@@ -37,7 +40,7 @@ public class HearingJourneyTests extends Base {
         createAndBuildCase(page);
 
         Hearing hearing = createListing(page);
-        hearing.createHearingSummary();
+        hearing.createHearingSummary(judge, panelMember);
         getTabByText(page, "Hearings").click();
         assertThat(page.locator("h4").first()).hasText("Listing details");
         String hearingStatus = getValueFromTableWithinHearingsTabFor(page, "Hearing Status");
@@ -46,10 +49,10 @@ public class HearingJourneyTests extends Base {
         Assertions.assertEquals("Case management", hearingType);
         String hearingFormat = getValueFromTableWithinHearingsTabFor(page, "Hearing format");
         Assertions.assertEquals("Face to Face", hearingFormat);
-        String judge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
-        Assertions.assertEquals("Chetan Lad", judge);
-        String panelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
-        Assertions.assertEquals("Joe Bloggs", panelMember);
+        String displayedJudge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
+        Assertions.assertEquals(judge, displayedJudge);
+        String displayedPanelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
+        Assertions.assertEquals(panelMember, displayedPanelMember);
         String otherAttendee = getValueFromTableWithinHearingsTabFor(page, "Who was this other attendee?");
         Assertions.assertEquals("Special officer", otherAttendee);
     }
@@ -60,7 +63,7 @@ public class HearingJourneyTests extends Base {
         createEditAndBuildDssCase(page);
 
         Hearing hearing = createListing(page);
-        hearing.createHearingSummary();
+        hearing.createHearingSummary(judge, panelMember);
         getTabByText(page, "Hearings").click();
         assertThat(page.locator("h4").first()).hasText("Listing details");
         String hearingStatus = getValueFromTableWithinHearingsTabFor(page, "Hearing Status");
@@ -69,10 +72,10 @@ public class HearingJourneyTests extends Base {
         Assertions.assertEquals("Case management", hearingType);
         String hearingFormat = getValueFromTableWithinHearingsTabFor(page, "Hearing format");
         Assertions.assertEquals("Face to Face", hearingFormat);
-        String judge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
-        Assertions.assertEquals("Chetan Lad", judge);
-        String panelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
-        Assertions.assertEquals("Joe Bloggs", panelMember);
+        String displayedJudge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
+        Assertions.assertEquals(judge, displayedJudge);
+        String displayedPanelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
+        Assertions.assertEquals(panelMember, displayedPanelMember);
         String otherAttendee = getValueFromTableWithinHearingsTabFor(page, "Who was this other attendee?");
         Assertions.assertEquals("Special officer", otherAttendee);
     }
@@ -83,8 +86,8 @@ public class HearingJourneyTests extends Base {
         createAndBuildCase(page);
 
         Hearing hearing = createListing(page);
-        hearing.createHearingSummary();
-        hearing.editHearingSummary();
+        hearing.createHearingSummary(judge, panelMember);
+        hearing.editHearingSummary(judge, panelMember);
         getTabByText(page, "Hearings").click();
         assertThat(page.locator("h4").first()).hasText("Listing details");
         String hearingStatus = getValueFromTableWithinHearingsTabFor(page, "Hearing Status");
@@ -93,10 +96,10 @@ public class HearingJourneyTests extends Base {
         Assertions.assertEquals("Final", hearingType);
         String hearingFormat = getValueFromTableWithinHearingsTabFor(page, "Hearing format");
         Assertions.assertEquals("Hybrid", hearingFormat);
-        String judge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
-        Assertions.assertEquals("Chetan Lad", judge);
-        String panelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
-        Assertions.assertEquals("Joe Bloggs", panelMember);
+        String displayedJudge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
+        Assertions.assertEquals(judge, displayedJudge);
+        String displayedPanelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
+        Assertions.assertEquals(panelMember, displayedPanelMember);
         String otherAttendee = getValueFromTableWithinHearingsTabFor(page, "Who was this other attendee?");
         Assertions.assertEquals("Special officer", otherAttendee);
     }

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueADecisionTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueADecisionTests.java
@@ -27,7 +27,9 @@ public class IssueADecisionTests extends Base {
         newCase.buildCase();
         Hearing hearing = new Hearing(page);
         hearing.createListing();
-        hearing.createHearingSummary();
+        String judge = "Carys Cotton";
+        String panelMember = "Dr Aaron Owens";
+        hearing.createHearingSummary(judge, panelMember);
         newCase.startNextStepAction(IssueDecision);
         assertThat(page.locator("h1"))
             .hasText("Create a decision notice", textOptionsWithTimeout(60000));

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueFinalDecisionTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueFinalDecisionTests.java
@@ -27,7 +27,9 @@ public class IssueFinalDecisionTests extends Base {
         newCase.buildCase();
         Hearing hearing = new Hearing(page);
         hearing.createListing();
-        hearing.createHearingSummary();
+        String judge = "Carys Cotton";
+        String panelMember = "Dr Aaron Owens";
+        hearing.createHearingSummary(judge, panelMember);
         newCase.startNextStepAction(IssueFinalDecision);
         assertThat(page.locator("h1"))
             .hasText("Create a final decision notice", textOptionsWithTimeout(60000));


### PR DESCRIPTION
### Description ###

Judges and panelMembers reference data is updated as part of the elink judicial data refresh. This is causing the failure of Hearing Journey E2E Tests. This PR updates the Judges and panelMembers data in the E2E tests to fix the failing tests on the master pipeline.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ST-1079

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)