### PR TITLE
Fix and update e2e tests to fix failure on firefox browser

### DIFF
--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Base.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Base.java
@@ -70,7 +70,7 @@ public abstract class Base {
         }
         page = context.newPage();
         page.setDefaultTimeout(30000);
-        page.setDefaultNavigationTimeout(30000);
+        page.setDefaultNavigationTimeout(60000);
         String url = getenv("CASE_API_BASE_URL");
         CASE_API_BASE_URL = url == null || url.equals("null") ? CASE_API_AAT_URL : url;
         page.navigate(CASE_API_BASE_URL, new Page.NavigateOptions().setTimeout(120000));

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Case.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Case.java
@@ -48,9 +48,6 @@ public class Case {
 
     public static final String SELECT_A_VALUE = "--Select a value--";
     private final Page page;
-    private final String documentCategory = "A - Application Form";
-    private final String documentDescription = "This is a test document uploaded during create case journey";
-    private final String documentName = "sample_file.pdf";
 
     public Case(Page page) {
         this.page = page;
@@ -93,7 +90,7 @@ public class Case {
         Calendar date = DateHelpers.getYesterdaysDate();
         getTextBoxByLabel(page, "Day").fill(valueOf(date.get(Calendar.DAY_OF_MONTH)));
         getTextBoxByLabel(page, "Month").fill(valueOf(date.get(Calendar.MONTH) + 1));
-        getTextBoxByLabel(page, "Year").type(valueOf(date.get(Calendar.YEAR)));
+        getTextBoxByLabel(page, "Year").fill(valueOf(date.get(Calendar.YEAR)));
         clickButton(page, "Continue");
 
         // Fill identified parties form
@@ -173,7 +170,7 @@ public class Case {
 
         // Fill contact preferences form
         assertThat(page.locator("h1"))
-            .hasText("Who should receive information about the case?", textOptionsWithTimeout(30000));
+            .hasText("Who should receive information about the case?", textOptionsWithTimeout(60000));
         getCheckBoxByLabel(page, "Subject").first().check();
         if (page.isVisible("#cicCaseApplicantCIC-ApplicantCIC")) {
             getCheckBoxByLabel(page, "Applicant (if different from subject)").check();
@@ -185,20 +182,23 @@ public class Case {
 
         // Upload tribunals form
         assertThat(page.locator("h1"))
-            .hasText("Upload tribunal forms", textOptionsWithTimeout(30000));
+            .hasText("Upload tribunal forms", textOptionsWithTimeout(60000));
         clickButton(page, "Add new");
+        String documentCategory = "A - Application Form";
         page.selectOption("#cicCaseApplicantDocumentsUploaded_0_documentCategory", new SelectOption().setLabel(documentCategory));
+        String documentName = "sample_file.pdf";
         page.setInputFiles("input[type='file']", Paths.get("src/e2eTests/java/uk/gov/hmcts/sptribs/testutils/files/" + documentName));
         page.waitForSelector("//span[contains(text(), 'Uploading...')]",
             new Page.WaitForSelectorOptions().setState(WaitForSelectorState.DETACHED));
         page.waitForFunction("selector => document.querySelector(selector).disabled === true",
             "button[aria-label='Cancel upload']", functionOptionsWithTimeout(15000));
+        String documentDescription = "This is a test document uploaded during create case journey";
         page.locator("#cicCaseApplicantDocumentsUploaded_0_documentEmailContent").fill(documentDescription);
         clickButton(page, "Continue");
 
         // Fill further details form
         assertThat(page.locator("h1"))
-            .hasText("Enter further details about this case", textOptionsWithTimeout(30000));
+            .hasText("Enter further details about this case", textOptionsWithTimeout(60000));
         page.selectOption("#cicCaseSchemeCic", new SelectOption().setLabel("2001"));
         page.selectOption("#cicCaseRegionCIC", new SelectOption().setLabel("London"));
         page.locator("#cicCaseClaimLinkedToCic_Yes").click();
@@ -211,7 +211,7 @@ public class Case {
         // Check your answers form
         page.waitForSelector("h2.heading-h2", selectorOptionsWithTimeout(30000));
         assertThat(page.locator("h2.heading-h2"))
-            .hasText("Check your answers", textOptionsWithTimeout(30000));
+            .hasText("Check your answers", textOptionsWithTimeout(60000));
         clickButton(page, "Save and continue");
 
         // Case created confirmation screen

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Case.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Case.java
@@ -90,7 +90,7 @@ public class Case {
         Calendar date = DateHelpers.getYesterdaysDate();
         getTextBoxByLabel(page, "Day").fill(valueOf(date.get(Calendar.DAY_OF_MONTH)));
         getTextBoxByLabel(page, "Month").fill(valueOf(date.get(Calendar.MONTH) + 1));
-        getTextBoxByLabel(page, "Year").fill(valueOf(date.get(Calendar.YEAR)));
+        getTextBoxByLabel(page, "Year").type(valueOf(date.get(Calendar.YEAR)));
         clickButton(page, "Continue");
 
         // Fill identified parties form

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Hearing.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Hearing.java
@@ -1,14 +1,18 @@
 package uk.gov.hmcts.sptribs.e2e;
 
+import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.SelectOption;
+import com.microsoft.playwright.options.WaitForSelectorState;
 import org.junit.jupiter.api.Assertions;
 import uk.gov.hmcts.sptribs.testutils.DateHelpers;
 import uk.gov.hmcts.sptribs.testutils.PageHelpers;
 
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Random;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static uk.gov.hmcts.sptribs.e2e.enums.Actions.CancelHearing;
@@ -203,7 +207,7 @@ public class Hearing {
         Assertions.assertEquals(AwaitingHearing.label, newCase.getCaseStatus());
     }
 
-    public void createHearingSummary(String judge, String panelMember) {
+    public HashMap<String, String> createHearingSummary() {
         Case newCase = new Case(page);
         newCase.startNextStepAction(CreateSummary);
 
@@ -225,9 +229,14 @@ public class Hearing {
         // Fill Hearing attendees form
         assertThat(page.locator("h1"))
             .hasText("Hearing attendees", textOptionsWithTimeout(30000));
+        HashMap<String, String> map = new HashMap<>();
+        String judge = getRandomNameFromJudgesList(page);
+        map.put("judge", judge);
         page.selectOption("#judge", new SelectOption().setLabel(judge));
         getRadioButtonByLabel(page, "Yes").click();
         clickButton(page, "Add new");
+        String panelMember = getRandomNameFromPanelMembersList(page);
+        map.put("panelMember", panelMember);
         page.selectOption("#memberList_0_name", new SelectOption().setLabel(panelMember));
         getRadioButtonByLabel(page, "Full member").click();
         PageHelpers.clickButton(page, "Continue");
@@ -235,7 +244,7 @@ public class Hearing {
         // Fill Hearing attendees second form
         assertThat(page.locator("h1"))
             .hasText("Hearing attendees", textOptionsWithTimeout(30000));
-        getCheckBoxByLabel(page, "Appellant").first().check();
+        page.locator("#roles-appellant").check();
         getCheckBoxByLabel(page, "Observer").check();
         getCheckBoxByLabel(page, "Other").check();
         getTextBoxByLabel(page, "Who was this other attendee?").fill("Special officer");
@@ -268,9 +277,10 @@ public class Hearing {
         assertThat(page.locator("h2.heading-h2").first())
             .hasText("History", textOptionsWithTimeout(60000));
         Assertions.assertEquals(AwaitingOutcome.label, newCase.getCaseStatus());
+        return map;
     }
 
-    public void editHearingSummary(String judge, String panelMember) {
+    public HashMap<String, String> editHearingSummary() {
         Case newCase = new Case(page);
         newCase.startNextStepAction(EditSummary);
 
@@ -297,8 +307,13 @@ public class Hearing {
         // Fill Hearing attendees form
         assertThat(page.locator("h1"))
             .hasText("Hearing attendees", textOptionsWithTimeout(30000));
+        HashMap<String, String> map = new HashMap<>();
+        String judge = getRandomNameFromJudgesList(page);
+        map.put("judge", judge);
         page.selectOption("#judge", new SelectOption().setLabel(judge));
         getRadioButtonByLabel(page, "Yes").click();
+        String panelMember = getRandomNameFromPanelMembersList(page);
+        map.put("panelMember", panelMember);
         page.selectOption("#memberList_0_name", new SelectOption().setLabel(panelMember));
         getRadioButtonByLabel(page, "Observer").click();
         PageHelpers.clickButton(page, "Continue");
@@ -306,7 +321,7 @@ public class Hearing {
         // Fill Hearing attendees second form
         assertThat(page.locator("h1"))
             .hasText("Hearing attendees", textOptionsWithTimeout(30000));
-        getCheckBoxByLabel(page, "Appellant").first().check();
+        page.locator("#roles-appellant").check();
         getCheckBoxByLabel(page, "Observer").check();
         getCheckBoxByLabel(page, "Other").check();
         getTextBoxByLabel(page, "Who was this other attendee?").fill("Special officer");
@@ -338,6 +353,7 @@ public class Hearing {
         assertThat(page.locator("h2.heading-h2").first())
             .hasText("History", textOptionsWithTimeout(60000));
         Assertions.assertEquals(AwaitingOutcome.label, newCase.getCaseStatus());
+        return map;
     }
 
     public void cancelHearing() {
@@ -428,5 +444,30 @@ public class Hearing {
         }
         getCheckBoxByLabel(page, "Respondent").check();
         clickButton(page, "Continue");
+    }
+
+    private String getRandomNameFromJudgesList(Page page) {
+        page.waitForSelector("#judge",
+            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+        var elements = page.querySelectorAll("#judge option");
+        Assertions.assertTrue(elements.size() > 1, "Judges list is not loaded");
+        return getRandomOptionFromTheList(elements);
+    }
+
+    private String getRandomNameFromPanelMembersList(Page page) {
+        page.waitForSelector("#memberList_0_name",
+            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+        var elements = page.querySelectorAll("#memberList_0_name option");
+        Assertions.assertTrue(elements.size() > 1, "Panel members list is not loaded");
+        return getRandomOptionFromTheList(elements);
+    }
+
+    private String getRandomOptionFromTheList(List<ElementHandle> list) {
+        var elements = list.subList(1, list.size());
+        return (String) elements.stream()
+            .skip(new Random().nextInt(elements.size()))
+            .findFirst()
+            .map(ElementHandle::textContent)
+            .orElse("");
     }
 }

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Hearing.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Hearing.java
@@ -450,7 +450,7 @@ public class Hearing {
         page.waitForSelector("#judge",
             new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
         var elements = page.querySelectorAll("#judge option");
-        Assertions.assertTrue(elements.size() > 1, "Judges list is not loaded");
+        Assertions.assertTrue(elements.size() > 1, "Judges dropdown list is empty");
         return getRandomOptionFromTheList(elements);
     }
 
@@ -458,7 +458,7 @@ public class Hearing {
         page.waitForSelector("#memberList_0_name",
             new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
         var elements = page.querySelectorAll("#memberList_0_name option");
-        Assertions.assertTrue(elements.size() > 1, "Panel members list is not loaded");
+        Assertions.assertTrue(elements.size() > 1, "Panel members dropdown list is empty");
         return getRandomOptionFromTheList(elements);
     }
 

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/HearingJourneyTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/HearingJourneyTests.java
@@ -5,6 +5,8 @@ import io.github.artsok.RepeatedIfExceptionsTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 
+import java.util.HashMap;
+
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static uk.gov.hmcts.sptribs.e2e.enums.CaseState.DssSubmitted;
 import static uk.gov.hmcts.sptribs.testutils.AssertionHelpers.visibleOptionsWithTimeout;
@@ -13,9 +15,6 @@ import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getCaseUrl;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getTabByText;
 
 public class HearingJourneyTests extends Base {
-
-    private final String judge = "Carys Cotton";
-    private final String panelMember = "Dr Aaron Owens";
 
     @RepeatedIfExceptionsTest
     public void caseWorkerShouldBeAbleToEditListingAndViewDetailsInHearingTab() {
@@ -40,7 +39,7 @@ public class HearingJourneyTests extends Base {
         createAndBuildCase(page);
 
         Hearing hearing = createListing(page);
-        hearing.createHearingSummary(judge, panelMember);
+        final HashMap<String, String> map = hearing.createHearingSummary();
         getTabByText(page, "Hearings").click();
         assertThat(page.locator("h4").first()).hasText("Listing details");
         String hearingStatus = getValueFromTableWithinHearingsTabFor(page, "Hearing Status");
@@ -50,9 +49,9 @@ public class HearingJourneyTests extends Base {
         String hearingFormat = getValueFromTableWithinHearingsTabFor(page, "Hearing format");
         Assertions.assertEquals("Face to Face", hearingFormat);
         String displayedJudge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
-        Assertions.assertEquals(judge, displayedJudge);
+        Assertions.assertEquals(map.get("judge"), displayedJudge);
         String displayedPanelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
-        Assertions.assertEquals(panelMember, displayedPanelMember);
+        Assertions.assertEquals(map.get("panelMember"), displayedPanelMember);
         String otherAttendee = getValueFromTableWithinHearingsTabFor(page, "Who was this other attendee?");
         Assertions.assertEquals("Special officer", otherAttendee);
     }
@@ -63,7 +62,7 @@ public class HearingJourneyTests extends Base {
         createEditAndBuildDssCase(page);
 
         Hearing hearing = createListing(page);
-        hearing.createHearingSummary(judge, panelMember);
+        final HashMap<String, String> map = hearing.createHearingSummary();
         getTabByText(page, "Hearings").click();
         assertThat(page.locator("h4").first()).hasText("Listing details");
         String hearingStatus = getValueFromTableWithinHearingsTabFor(page, "Hearing Status");
@@ -73,9 +72,9 @@ public class HearingJourneyTests extends Base {
         String hearingFormat = getValueFromTableWithinHearingsTabFor(page, "Hearing format");
         Assertions.assertEquals("Face to Face", hearingFormat);
         String displayedJudge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
-        Assertions.assertEquals(judge, displayedJudge);
+        Assertions.assertEquals(map.get("judge"), displayedJudge);
         String displayedPanelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
-        Assertions.assertEquals(panelMember, displayedPanelMember);
+        Assertions.assertEquals(map.get("panelMember"), displayedPanelMember);
         String otherAttendee = getValueFromTableWithinHearingsTabFor(page, "Who was this other attendee?");
         Assertions.assertEquals("Special officer", otherAttendee);
     }
@@ -86,8 +85,8 @@ public class HearingJourneyTests extends Base {
         createAndBuildCase(page);
 
         Hearing hearing = createListing(page);
-        hearing.createHearingSummary(judge, panelMember);
-        hearing.editHearingSummary(judge, panelMember);
+        hearing.createHearingSummary();
+        final HashMap<String, String> map =  hearing.editHearingSummary();
         getTabByText(page, "Hearings").click();
         assertThat(page.locator("h4").first()).hasText("Listing details");
         String hearingStatus = getValueFromTableWithinHearingsTabFor(page, "Hearing Status");
@@ -97,9 +96,9 @@ public class HearingJourneyTests extends Base {
         String hearingFormat = getValueFromTableWithinHearingsTabFor(page, "Hearing format");
         Assertions.assertEquals("Hybrid", hearingFormat);
         String displayedJudge = getValueFromTableWithinHearingsTabFor(page, "Which judge heard the case?");
-        Assertions.assertEquals(judge, displayedJudge);
+        Assertions.assertEquals(map.get("judge"), displayedJudge);
         String displayedPanelMember = getValueFromTableWithinHearingsTabFor(page, "Name of the panel member");
-        Assertions.assertEquals(panelMember, displayedPanelMember);
+        Assertions.assertEquals(map.get("panelMember"), displayedPanelMember);
         String otherAttendee = getValueFromTableWithinHearingsTabFor(page, "Who was this other attendee?");
         Assertions.assertEquals("Special officer", otherAttendee);
     }

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueADecisionTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueADecisionTests.java
@@ -27,9 +27,7 @@ public class IssueADecisionTests extends Base {
         newCase.buildCase();
         Hearing hearing = new Hearing(page);
         hearing.createListing();
-        String judge = "Carys Cotton";
-        String panelMember = "Dr Aaron Owens";
-        hearing.createHearingSummary(judge, panelMember);
+        hearing.createHearingSummary();
         newCase.startNextStepAction(IssueDecision);
         assertThat(page.locator("h1"))
             .hasText("Create a decision notice", textOptionsWithTimeout(60000));

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueFinalDecisionTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/IssueFinalDecisionTests.java
@@ -27,9 +27,7 @@ public class IssueFinalDecisionTests extends Base {
         newCase.buildCase();
         Hearing hearing = new Hearing(page);
         hearing.createListing();
-        String judge = "Carys Cotton";
-        String panelMember = "Dr Aaron Owens";
-        hearing.createHearingSummary(judge, panelMember);
+        hearing.createHearingSummary();
         newCase.startNextStepAction(IssueFinalDecision);
         assertThat(page.locator("h1"))
             .hasText("Create a final decision notice", textOptionsWithTimeout(60000));

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Login.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Login.java
@@ -83,7 +83,7 @@ public class Login {
     }
 
     public void loginAsStTest1User() {
-        loginAs("st-test1@mailinator.com");
+        loginAs(getenv("SENIOR_LEGAL_OFFICER"));
     }
 
     public void loginAsHearingCentreTL() {

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ReferCaseToJudgeTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ReferCaseToJudgeTests.java
@@ -5,6 +5,7 @@ import com.microsoft.playwright.options.SelectOption;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import uk.gov.hmcts.sptribs.e2e.enums.Actions;
 import uk.gov.hmcts.sptribs.testutils.PageHelpers;
 
@@ -32,6 +33,7 @@ public class ReferCaseToJudgeTests extends Base {
         assertThat(page.locator("h1")).hasText(Actions.ReferCaseToJudge.label, textOptionsWithTimeout(60000));
     }
 
+    @Order(1)
     @RepeatedIfExceptionsTest
     public void caseworkerShouldAbleToReferCaseToJudge() {
         page.selectOption("#referToJudgeReferralReason",
@@ -51,6 +53,7 @@ public class ReferCaseToJudgeTests extends Base {
         Assertions.assertEquals(CaseManagement.label, newCase.getCaseStatus());
     }
 
+    @Order(2)
     @RepeatedIfExceptionsTest
     public void errorInvalidCaseStatusReferCaseToJudge() {
         page.selectOption("#referToJudgeReferralReason",

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ReferCaseToLegalOfficerTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ReferCaseToLegalOfficerTests.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.sptribs.e2e;
 import com.microsoft.playwright.Page;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,6 +29,7 @@ public class ReferCaseToLegalOfficerTests extends Base {
         assertThat(page.locator("h1")).hasText(ReferCaseToLegalOfficer.label, textOptionsWithTimeout(60000));
     }
 
+    @Order(1)
     @RepeatedIfExceptionsTest
     void referCaseToLegalOfficerTest() {
         assertThat(page.locator("h1")).hasText("Refer case to legal officer", textOptionsWithTimeout(60000));
@@ -47,6 +49,7 @@ public class ReferCaseToLegalOfficerTests extends Base {
         assertEquals(CaseManagement.label, newCase.getCaseStatus());
     }
 
+    @Order(2)
     @RepeatedIfExceptionsTest
     public void errorInvalidCaseStatusReferCaseToLegalOfficer() {
         page.selectOption("#referToLegalOfficerReferralReason", "Reinstatement request");


### PR DESCRIPTION
### Description ###

This PR:

1. fixes intermittent failure of e2e tests on Firefox browser
2. updates hearing e2e tests to select random value from judge and panel member dropdown lists to avoid failure if the judicial data is refreshed
3. sets order of execution for Refer to judge and Refer to legal officer e2e tests to avoid intermittent failure on CI pipeline

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ST-1172

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)

