### PR TITLE
e2e tests work around for server error message

### DIFF
--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DssCaseTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DssCaseTests.java
@@ -24,6 +24,7 @@ public class DssCaseTests extends Base {
         login.loginAsStCitizen1User();
         final String caseNumber = newDssCase.createCase("representative");
         clickLink(page, "Sign out");
+        login.refreshPageWhenServerErrorIsDisplayed();
         assertH1Heading(page, "Submit a First-tier Tribunal form");
         page.navigate(CASE_API_BASE_URL, new Page.NavigateOptions().setTimeout(90000));
         login.loginAsStTest1User();
@@ -43,6 +44,7 @@ public class DssCaseTests extends Base {
         login.loginAsStCitizen1User();
         final String caseNumber = newDssCase.createCase("representative", "pcq");
         clickLink(page, "Sign out");
+        login.refreshPageWhenServerErrorIsDisplayed();
         assertH1Heading(page, "Submit a First-tier Tribunal form");
         page.navigate(CASE_API_BASE_URL, new Page.NavigateOptions().setTimeout(90000));
         login.loginAsStTest1User();

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Login.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Login.java
@@ -28,18 +28,22 @@ public class Login {
     }
 
     private void loginAs(String user) {
+        refreshPageWhenServerErrorIsDisplayed();
         page.waitForSelector("h1:has-text(\"Sign in\")", selectorOptionsWithTimeout(120000));
         if (page.isVisible("#cookie-accept-submit")) {
             clickButton(page, "Accept additional cookies");
             page.locator("button[name=\"hide-accepted\"]").click();
         }
+        refreshPageWhenServerErrorIsDisplayed();
         enterCredentialsAndClickSignIn(user);
+        refreshPageWhenServerErrorIsDisplayed();
         page.waitForURL(CASE_API_BASE_URL + "/cases", urlOptionsWithTimeout(120000));
         assertThat(page.locator("h1"))
             .hasText("Case list", textOptionsWithTimeout(90000));
         if (page.isVisible("button[value=\"accept\"][name=\"cookies\"]")) {
             clickButton(page, "Accept analytics cookies");
             page.waitForLoadState(LoadState.DOMCONTENTLOADED,loadStateOptionsWithTimeout(120000));
+            refreshPageWhenServerErrorIsDisplayed();
             page.waitForURL(CASE_API_BASE_URL + "/cases", urlOptionsWithTimeout(90000));
             page.waitForSelector("h1", selectorOptionsWithTimeout(90000));
             assertThat(page.locator("h1"))
@@ -49,7 +53,7 @@ public class Login {
         page.waitForFunction("selector => document.querySelector(selector).options.length > 0",
             "#wb-jurisdiction", functionOptionsWithTimeout(120000));
         page.waitForSelector("xuilib-loading-spinner div.spinner-inner-container",
-            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.DETACHED));
+            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.DETACHED).setTimeout(60000));
     }
 
     private void enterCredentialsAndClickSignIn(String user) {
@@ -58,6 +62,7 @@ public class Login {
             getTextBoxByLabel(page, "Email address").fill(user);
             getTextBoxByLabel(page, "Password").fill(CASE_API_USER_PASSWORD);
             page.locator("input:has-text(\"Sign in\")").click(clickOptionsWithTimeout(120000));
+            refreshPageWhenServerErrorIsDisplayed();
             page.waitForLoadState(LoadState.DOMCONTENTLOADED, loadStateOptionsWithTimeout(120000));
             page.waitForSelector("h1", selectorOptionsWithTimeout(120000));
             i++;
@@ -103,5 +108,20 @@ public class Login {
 
     public void loginAsStCitizen1User() {
         loginAsDssUser(getenv("DSS_CITIZEN_USER"));
+    }
+
+    public void refreshPageWhenServerErrorIsDisplayed() {
+        int i = 0;
+        while (i <= 5) {
+            page.waitForSelector("body", selectorOptionsWithTimeout(60000));
+            String innerText = page.locator("body").innerText();
+            boolean errorDisplayed = innerText.contains("Internal Server Error");
+            if (errorDisplayed) {
+                page.reload();
+            } else {
+                break;
+            }
+            i++;
+        }
     }
 }

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ReferCaseToJudgeTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ReferCaseToJudgeTests.java
@@ -4,7 +4,6 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.SelectOption;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import uk.gov.hmcts.sptribs.e2e.enums.Actions;
 import uk.gov.hmcts.sptribs.testutils.PageHelpers;
@@ -18,31 +17,18 @@ import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getTextBoxByLabel;
 
 public class ReferCaseToJudgeTests extends Base {
 
-    private Page page;
-    private Case newCase;
-
-    @BeforeEach
-    void startReferCaseToJudgeJourney() {
-        page = getPage();
-        Login login = new Login(page);
-        login.loginAsHearingCentreTL();
-        newCase = new Case(page);
-        newCase.createCase();
-        newCase.buildCase();
-        newCase.startNextStepAction(Actions.ReferCaseToJudge);
-        assertThat(page.locator("h1")).hasText(Actions.ReferCaseToJudge.label, textOptionsWithTimeout(60000));
-    }
-
     @Order(1)
     @RepeatedIfExceptionsTest
     public void caseworkerShouldAbleToReferCaseToJudge() {
+        Page page = getPage();
+        startReferCaseToJudgeJourney(page);
         page.selectOption("#referToJudgeReferralReason",
             new SelectOption().setLabel("Time extension request"));
         PageHelpers.clickButton(page, "Continue");
         assertThat(page.locator("h1")).hasText("Additional information", textOptionsWithTimeout(60000));
         getTextBoxByLabel(page, "Provide additional details (Optional)").fill("test additional details");
         PageHelpers.clickButton(page, "Continue");
-        assertThat(page.locator("h2")).hasText("Check your answers", textOptionsWithTimeout(60000));
+        assertThat(page.locator("h2.heading-h2")).hasText("Check your answers", textOptionsWithTimeout(60000));
         PageHelpers.clickButton(page, "Continue");
         assertThat(page.locator("ccd-markdown markdown h1"))
             .hasText("Referral completed", textOptionsWithTimeout(30000));
@@ -50,17 +36,30 @@ public class ReferCaseToJudgeTests extends Base {
         clickButton(page, "Close and Return to case details");
         assertThat(page.locator("h2.heading-h2").first())
             .hasText("History", textOptionsWithTimeout(60000));
+        Case newCase = new Case(page);
         Assertions.assertEquals(CaseManagement.label, newCase.getCaseStatus());
     }
 
     @Order(2)
     @RepeatedIfExceptionsTest
     public void errorInvalidCaseStatusReferCaseToJudge() {
+        Page page = getPage();
+        startReferCaseToJudgeJourney(page);
         page.selectOption("#referToJudgeReferralReason",
             new SelectOption().setLabel("Reinstatement request"));
         PageHelpers.clickButton(page, "Continue");
         assertThat(page.locator("#errors li"))
             .hasText("The case state is incompatible with the selected referral reason", textOptionsWithTimeout(30000));
+    }
+
+    private void startReferCaseToJudgeJourney(Page page) {
+        Login login = new Login(page);
+        login.loginAsHearingCentreTL();
+        Case newCase = new Case(page);
+        newCase.createCase();
+        newCase.buildCase();
+        newCase.startNextStepAction(Actions.ReferCaseToJudge);
+        assertThat(page.locator("h1")).hasText(Actions.ReferCaseToJudge.label, textOptionsWithTimeout(60000));
     }
 }
 

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ReferCaseToLegalOfficerTests.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/ReferCaseToLegalOfficerTests.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.sptribs.e2e;
 
 import com.microsoft.playwright.Page;
 import io.github.artsok.RepeatedIfExceptionsTest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
@@ -14,24 +13,12 @@ import static uk.gov.hmcts.sptribs.testutils.PageHelpers.clickButton;
 import static uk.gov.hmcts.sptribs.testutils.PageHelpers.getTextBoxByLabel;
 
 public class ReferCaseToLegalOfficerTests extends Base {
-    private Page page;
-    private Case newCase;
-
-    @BeforeEach
-    void startReferCaseToLegalOfficerJourney() {
-        page = getPage();
-        Login login = new Login(page);
-        login.loginAsHearingCentreTL();
-        newCase = new Case(page);
-        newCase.createCase();
-        newCase.buildCase();
-        newCase.startNextStepAction(ReferCaseToLegalOfficer);
-        assertThat(page.locator("h1")).hasText(ReferCaseToLegalOfficer.label, textOptionsWithTimeout(60000));
-    }
 
     @Order(1)
     @RepeatedIfExceptionsTest
     void referCaseToLegalOfficerTest() {
+        Page page = getPage();
+        startReferCaseToLegalOfficerJourney(page);
         assertThat(page.locator("h1")).hasText("Refer case to legal officer", textOptionsWithTimeout(60000));
         page.selectOption("#referToLegalOfficerReferralReason", "Other");
         getTextBoxByLabel(page, "Reason for referral").fill("TEST");
@@ -39,22 +26,35 @@ public class ReferCaseToLegalOfficerTests extends Base {
         assertThat(page.locator("h1")).hasText("Additional information", textOptionsWithTimeout(60000));
         getTextBoxByLabel(page, "Provide additional details (Optional)").fill("Test additional details");
         clickButton(page, "Continue");
-        assertThat(page.locator("h2")).hasText("Check your answers", textOptionsWithTimeout(60000));
+        assertThat(page.locator("h2.heading-h2")).hasText("Check your answers", textOptionsWithTimeout(60000));
         clickButton(page, "Save and continue");
         assertThat(page.locator("ccd-markdown markdown h1"))
             .hasText("Referral completed", textOptionsWithTimeout(30000));
         clickButton(page, "Close and Return to case details");
         assertThat(page.locator("h2.heading-h2").first())
             .hasText("History", textOptionsWithTimeout(60000));
+        Case newCase = new Case(page);
         assertEquals(CaseManagement.label, newCase.getCaseStatus());
     }
 
     @Order(2)
     @RepeatedIfExceptionsTest
     public void errorInvalidCaseStatusReferCaseToLegalOfficer() {
+        Page page = getPage();
+        startReferCaseToLegalOfficerJourney(page);
         page.selectOption("#referToLegalOfficerReferralReason", "Reinstatement request");
         clickButton(page, "Continue");
         assertThat(page.locator("#errors li"))
             .hasText("The case state is incompatible with the selected referral reason", textOptionsWithTimeout(30000));
+    }
+
+    private void startReferCaseToLegalOfficerJourney(Page page) {
+        Login login = new Login(page);
+        login.loginAsHearingCentreTL();
+        Case newCase = new Case(page);
+        newCase.createCase();
+        newCase.buildCase();
+        newCase.startNextStepAction(ReferCaseToLegalOfficer);
+        assertThat(page.locator("h1")).hasText(ReferCaseToLegalOfficer.label, textOptionsWithTimeout(60000));
     }
 }


### PR DESCRIPTION
### Description ###

This PR:

1. adds a work around for server error on the environment where the page is refreshed when the error is displayed
2. Updates refer to judge and refer to legal officer tests

### JIRA link ###

https://tools.hmcts.net/jira/browse/ST-1079

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)