### PR TITLE
DTSSTCI-565: Created enable-e2e-tests label to run e2e tests on PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,14 +2,15 @@
 
 Enter a description.
 
-### JIRA link (if applicable) ###
+### JIRA link ###
 
-https://tools.hmcts.net/jira/browse/SPTRIBS-
+https://tools.hmcts.net/jira/browse/DTSSTCI-
 
 **Before merging a pull request make sure that:**
 
 - [ ] tests have been updated / new tests has been added (if needed)
 - [ ] README and other documentation has been updated / added (if needed)
+- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)
 
 **If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
 - [ ] this ticket been reviewed by QA

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,6 +6,7 @@ import uk.gov.hmcts.contino.AppPipelineConfig
 import uk.gov.hmcts.contino.AppPipelineDsl
 import uk.gov.hmcts.contino.GradleBuilder
 import uk.gov.hmcts.contino.MetricsPublisher
+import uk.gov.hmcts.contino.GithubAPI
 
 def type = "java"
 def product = "sptribs"
@@ -262,22 +263,23 @@ withPipeline(type, product, component) {
         generateDefinitions()
     }
 
-  /* afterSuccess('functionalTest:preview') {
-
-        try {
-            builder.gradle('e2eTests')
-        } finally {
-
-            publishHTML target: [
-                    allowMissing         : true,
-                    alwaysLinkToLastBuild: true,
-                    keepAll              : true,
-                    reportDir            : "build/reports/tests/e2eTests",
-                    reportFiles          : "index.html",
-                    reportName           : "E2E Tests Report"
-            ]
-        }
-    }*/
+  def githubApi = new GithubAPI(this) as Object
+  if (githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable-e2e-tests")) {
+    afterSuccess('functionalTest:preview') {
+      try {
+        builder.gradle('e2eTests')
+      } finally {
+        publishHTML target: [
+          allowMissing         : true,
+          alwaysLinkToLastBuild: true,
+          keepAll              : true,
+          reportDir            : "build/reports/tests/e2eTests",
+          reportFiles          : "index.html",
+          reportName           : "E2E Tests Report"
+        ]
+      }
+    }
+  }
 
 
   onDemo {


### PR DESCRIPTION
### Change description ###

enable-e2e-tests label can be used to run the e2e tests in PRs

### JIRA link  ###

https://tools.hmcts.net/jira/browse/DTSSTCI-565

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)