### PR TITLE
Small change to where GradleBuilder is instantiated.

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,7 +12,6 @@ properties([
 @Library("Infrastructure")
 
 import uk.gov.hmcts.contino.GradleBuilder
-GradleBuilder builder = new GradleBuilder(this, product)
 
 def type = "java"
 def product = "sptribs"
@@ -35,6 +34,8 @@ def secrets = [
     secret('citizen-password', 'IDAM_CITIZEN_PASSWORD')
   ]
 ]
+
+GradleBuilder builder = new GradleBuilder(this, product)
 
 withNightlyPipeline(type, product, component) {
   env.TEST_URL = "http://sptribs-case-api-aat.service.core-compute-aat.internal"


### PR DESCRIPTION
### Change description ###
Small change to where GradleBuilder is instantiated on our nightly pipeline as the config is causing our pipelines to fail

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)
- [x] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [x] this ticket has been reviewed by QA
- [x] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

