### PR TITLE
DTSSTCI-825

### DIFF
--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerCreateBundle.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerCreateBundle.java
@@ -89,7 +89,10 @@ public class CaseworkerCreateBundle implements CCDConfig<CaseData, State, UserRo
         final List<AbstractCaseworkerCICDocument<CaseworkerCICDocument>> abstractCaseworkerCICDocumentList = new ArrayList<>();
 
         for (ListValue<CaseworkerCICDocument> caseworkerCICDocumentListValue : documentListValues) {
-            abstractCaseworkerCICDocumentList.add(new AbstractCaseworkerCICDocument<>(caseworkerCICDocumentListValue.getValue()));
+            CaseworkerCICDocument document = caseworkerCICDocumentListValue.getValue();
+            if (document.isValidBundleDocument()) {
+                abstractCaseworkerCICDocumentList.add(new AbstractCaseworkerCICDocument<>(caseworkerCICDocumentListValue.getValue()));
+            }
         }
 
         caseData.setCaseDocuments(abstractCaseworkerCICDocumentList);

--- a/src/main/java/uk/gov/hmcts/sptribs/document/DocumentUtil.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/DocumentUtil.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.sptribs.document.model.DocumentInfo;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils.substringAfterLast;
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 import static uk.gov.hmcts.sptribs.document.DocumentConstants.DOCUMENT_VALIDATION_MESSAGE;
 
 public final class DocumentUtil {

--- a/src/main/java/uk/gov/hmcts/sptribs/document/DocumentUtil.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/DocumentUtil.java
@@ -11,8 +11,10 @@ import uk.gov.hmcts.sptribs.document.model.CaseworkerCICDocument;
 import uk.gov.hmcts.sptribs.document.model.DocumentInfo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import static com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils.substringAfterLast;
 import static uk.gov.hmcts.sptribs.document.DocumentConstants.DOCUMENT_VALIDATION_MESSAGE;
 
 public final class DocumentUtil {
@@ -112,6 +114,11 @@ public final class DocumentUtil {
         }
 
         return errors;
+    }
+
+    public static boolean isValidDocument(String fileName, String validExtensions) {
+        String fileExtension = substringAfterLast(fileName, ".");
+        return fileExtension != null && validExtensions.contains(fileExtension);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/sptribs/document/DocumentUtil.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/DocumentUtil.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.sptribs.document.model.CaseworkerCICDocument;
 import uk.gov.hmcts.sptribs.document.model.DocumentInfo;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils.substringAfterLast;

--- a/src/main/java/uk/gov/hmcts/sptribs/document/model/CICDocument.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/model/CICDocument.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.sptribs.ciccase.model.access.CaseworkerWithCAAAccess;
 import uk.gov.hmcts.sptribs.ciccase.model.access.DefaultAccess;
 
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.TextArea;
+import static uk.gov.hmcts.sptribs.document.DocumentUtil.isValidDocument;
 
 @Data
 @NoArgsConstructor
@@ -42,10 +43,9 @@ public class CICDocument {
 
     @JsonIgnore
     public boolean isDocumentValid() {
-        String regex = ".pdf,.csv,.txt,.rtf,.xlsx,.docx,.doc,.xls,.tif,.tiff,.jpg,.jpeg,.png,.mp3,.m4a,.mp4";
-        String fileName = this.documentLink.getFilename();
-        String fileExtension = StringUtils.substringAfter(fileName, ".");
-
-        return regex.contains(fileExtension);
+        return isValidDocument(
+            this.documentLink.getFilename(),
+            "pdf,csv,txt,rtf,xlsx,docx,doc,xls,tif,tiff,jpg,jpeg,png,mp3,m4a,mp4"
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/sptribs/document/model/CICDocument.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/model/CICDocument.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.sptribs.ciccase.model.access.CaseworkerWithCAAAccess;

--- a/src/main/java/uk/gov/hmcts/sptribs/document/model/CaseworkerCICDocument.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/model/CaseworkerCICDocument.java
@@ -63,6 +63,7 @@ public class CaseworkerCICDocument {
         return isValidDocument(this.documentLink.getFilename(), validExtensions);
     }
 
+    @JsonIgnore
     public boolean isValidBundleDocument() {
         return isValidDocument(this.documentLink.getFilename(),"pdf,txt,xlsx,docx,doc,xls");
     }

--- a/src/main/java/uk/gov/hmcts/sptribs/document/model/CaseworkerCICDocument.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/model/CaseworkerCICDocument.java
@@ -6,13 +6,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.sptribs.ciccase.model.access.CaseworkerWithCAAAccess;
 import uk.gov.hmcts.sptribs.ciccase.model.access.DefaultAccess;
-
-import java.util.Arrays;
 
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.TextArea;

--- a/src/main/java/uk/gov/hmcts/sptribs/document/model/CaseworkerCICDocument.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/document/model/CaseworkerCICDocument.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.TextArea;
+import static uk.gov.hmcts.sptribs.document.DocumentUtil.isValidDocument;
 
 @Data
 @NoArgsConstructor
@@ -55,12 +56,14 @@ public class CaseworkerCICDocument {
 
     @JsonIgnore
     public boolean isDocumentValid() {
-        return isDocumentValid("pdf,csv,txt,rtf,xlsx,docx,doc,xls,mp3,m4a,mp4");
+        return isValidDocument(this.documentLink.getFilename(), "pdf,csv,txt,rtf,xlsx,docx,doc,xls,mp3,m4a,mp4");
     }
 
     public boolean isDocumentValid(String validExtensions) {
-        String fileName = this.documentLink.getFilename();
-        String fileExtension = StringUtils.substringAfterLast(fileName, ".");
-        return Arrays.asList(validExtensions.split(",")).contains(fileExtension);
+        return isValidDocument(this.documentLink.getFilename(), validExtensions);
+    }
+
+    public boolean isValidBundleDocument() {
+        return isValidDocument(this.documentLink.getFilename(),"pdf,txt,xlsx,docx,doc,xls");
     }
 }

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerCreateBundleTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerCreateBundleTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.sptribs.document.bundling.model.Bundle;
 import uk.gov.hmcts.sptribs.document.bundling.model.BundleCallback;
 import uk.gov.hmcts.sptribs.document.bundling.model.MultiBundleConfig;
 import uk.gov.hmcts.sptribs.document.model.CaseworkerCICDocument;
-import uk.gov.hmcts.sptribs.testutil.TestDataHelper;
 
 import java.util.List;
 
@@ -33,6 +32,7 @@ import static uk.gov.hmcts.sptribs.testutil.ConfigTestUtil.getEventsFrom;
 import static uk.gov.hmcts.sptribs.testutil.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.sptribs.testutil.TestDataHelper.LOCAL_DATE_TIME;
 import static uk.gov.hmcts.sptribs.testutil.TestDataHelper.caseData;
+import static uk.gov.hmcts.sptribs.testutil.TestDataHelper.getCaseworkerCICDocumentList;
 import static uk.gov.hmcts.sptribs.testutil.TestEventConstants.CREATE_BUNDLE;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,7 +70,7 @@ class CaseworkerCreateBundleTest {
     @Test
     public void shouldSuccessfullyCreateBundle() {
         final CaseData caseData = caseData();
-        final List<ListValue<CaseworkerCICDocument>> cicDocuments = TestDataHelper.getCaseworkerCICDocumentList();
+        final List<ListValue<CaseworkerCICDocument>> cicDocuments = getCaseworkerCICDocumentList();
         final CicCase cicCase = CicCase.builder().build();
         cicCase.setApplicantDocumentsUploaded(cicDocuments);
         caseData.setCicCase(cicCase);
@@ -111,6 +111,49 @@ class CaseworkerCreateBundleTest {
 
         //case documents should remain null so that they are not duplicated
         //i.e. not in their respective child objects as well (CicCase.applicantDocumentsUploaded)
+        assertThat(responseData.getCaseDocuments()).isNull();
+        assertThat(responseData.getMultiBundleConfiguration()).isNull();
+    }
+
+    @Test
+    public void shouldIgnoreInvalidFilesWhenCreatingBundle() {
+        final CaseData caseData = caseData();
+        final List<ListValue<CaseworkerCICDocument>> documents = getCaseworkerCICDocumentList("test.mp3");
+        final CicCase cicCase = CicCase.builder().build();
+        cicCase.setApplicantDocumentsUploaded(documents);
+        caseData.setCicCase(cicCase);
+        final CaseDetails<CaseData, State> updatedCaseDetails = new CaseDetails<>();
+        updatedCaseDetails.setData(caseData);
+        updatedCaseDetails.setId(TEST_CASE_ID);
+        updatedCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        final Bundle bundle = Bundle.builder().build();
+
+        when(bundlingService.getMultiBundleConfig()).thenCallRealMethod();
+        when(bundlingService.getMultiBundleConfigs()).thenCallRealMethod();
+
+        when(bundlingService.createBundle(any(BundleCallback.class))).thenAnswer(callback -> {
+            final BundleCallback callbackAtMockTime = (BundleCallback) callback.getArguments()[0];
+
+            final CaseData dataAtMockTime = callbackAtMockTime.getCaseDetails().getData();
+            assertThat(dataAtMockTime.getCaseDocuments()).isEmpty();
+            assertThat(dataAtMockTime.getBundleConfiguration()).isEqualTo(MULTI_BUNDLE_CONFIG);
+            assertThat(dataAtMockTime.getMultiBundleConfiguration()).isEqualTo(List.of(MULTI_BUNDLE_CONFIG));
+            return List.of(bundle);
+        });
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            caseworkerCreateBundle.aboutToSubmit(updatedCaseDetails, CaseDetails.<CaseData, State>builder().build());
+
+        verify(bundlingService).getMultiBundleConfig();
+        verify(bundlingService).getMultiBundleConfigs();
+        verify(bundlingService).buildBundleListValues(anyList());
+
+        final CaseData responseData = response.getData();
+        assertThat(responseData)
+            .isNotNull()
+            .isEqualTo(updatedCaseDetails.getData());
+        assertThat(responseData.getCaseBundles()).isNotNull();
         assertThat(responseData.getCaseDocuments()).isNull();
         assertThat(responseData.getMultiBundleConfiguration()).isNull();
     }

--- a/src/test/java/uk/gov/hmcts/sptribs/document/DocumentUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/document/DocumentUtilTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.sptribs.document;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
@@ -17,6 +19,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.sptribs.document.DocumentConstants.DOCUMENT_VALIDATION_MESSAGE;
 import static uk.gov.hmcts.sptribs.document.DocumentUtil.documentFrom;
 import static uk.gov.hmcts.sptribs.document.DocumentUtil.updateCategoryToCaseworkerDocument;
@@ -514,6 +518,41 @@ class DocumentUtilTest {
         assertThat(errors).contains("Description is mandatory for each document");
         assertThat(errors).contains("Category is mandatory for each document");
         assertThat(errors).contains("Please attach the document");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "test.pdf",
+        "test.txt",
+        "test.rtf",
+        "test.xlsx",
+        "test.docx",
+        "test.doc",
+        "test.xls",
+    })
+    void shouldCheckValidFileTypeInList(String filename) {
+        assertTrue(DocumentUtil.isValidDocument(filename, "pdf,txt,rtf,xlsx,docx,doc,xls"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "test.mp3",
+        "test.mp4",
+        "test.csv",
+        "test.jpeg",
+    })
+    void shouldCheckInvalidFileTypeInList(String filename) {
+        assertFalse(DocumentUtil.isValidDocument(filename, "pdf,txt,rtf,xlsx,docx,doc,xls"));
+    }
+
+    @Test
+    void shouldCheckValidFileWithOnlyOneValidFileType() {
+        assertTrue(DocumentUtil.isValidDocument("test.mp3", "mp3"));
+    }
+
+    @Test
+    void shouldCheckFileWithNullFileName() {
+        assertFalse(DocumentUtil.isValidDocument(null, "mp3"));
     }
 
     private DocumentInfo documentInfo() {

--- a/src/test/java/uk/gov/hmcts/sptribs/document/model/CaseworkerCICDocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/document/model/CaseworkerCICDocumentTest.java
@@ -23,7 +23,7 @@ class CaseworkerCICDocumentTest {
         "test.m4a",
         "test.mp4"
     })
-    void shouldCheckIsValid(String filename) {
+    void shouldCheckDocumentIsValid(String filename) {
         CaseworkerCICDocument document = CaseworkerCICDocument.builder()
             .documentCategory(DocumentType.LINKED_DOCS)
             .documentLink(Document.builder().filename(filename).build())
@@ -39,12 +39,50 @@ class CaseworkerCICDocumentTest {
         "test.msg",
         "test.uml"
     })
-    void shouldCheckIsValidInvalid(String filename) {
+    void shouldCheckDocumentIsInvalid(String filename) {
         CaseworkerCICDocument document = CaseworkerCICDocument.builder()
             .documentCategory(DocumentType.LINKED_DOCS)
             .documentLink(Document.builder().filename(filename).build())
             .build();
 
         assertFalse(document.isDocumentValid());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "test.pdf",
+        "test.txt",
+        "test.xlsx",
+        "test.docx",
+        "test.doc",
+        "test.xls",
+    })
+    void shouldCheckIsValidBundleDocument(String filename) {
+        CaseworkerCICDocument document = CaseworkerCICDocument.builder()
+            .documentCategory(DocumentType.LINKED_DOCS)
+            .documentLink(Document.builder().filename(filename).build())
+            .build();
+
+        assertTrue(document.isValidBundleDocument());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "test.xml",
+        "test.eml",
+        "test.msg",
+        "test.uml",
+        "test.csv",
+        "test.mp3",
+        "test.m4a",
+        "test.mp4"
+    })
+    void shouldCheckIsInvalidBundleDocument(String filename) {
+        CaseworkerCICDocument document = CaseworkerCICDocument.builder()
+            .documentCategory(DocumentType.LINKED_DOCS)
+            .documentLink(Document.builder().filename(filename).build())
+            .build();
+
+        assertFalse(document.isValidBundleDocument());
     }
 }


### PR DESCRIPTION
### Change description ###
Filter documents when bundling so that the only the following file types are included: pdf, txt, rtf, xls, xlsx, doc and docx.
CSV files are not included because they are not considered a compatible in em-stiching-api.
RFT files are not included because they are only partially compatible. RFT files have two possible mimetypes (application/rtf and text/rtf) and bundling is only compatible with application/rtf in em-stiching-api.

### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSSTCI-825

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket has been reviewed by QA
- [ ] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

