### PR TITLE
DTSSTCI-850 - E2E tests selectors fix

### DIFF
--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Case.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/Case.java
@@ -191,7 +191,7 @@ public class Case {
             .hasText("Upload tribunal forms", textOptionsWithTimeout(60000));
         clickButton(page, "Add new");
         String documentCategory = "A - Application Form";
-        page.selectOption("#cicCaseApplicantDocumentsUpload_0_documentCategory", new SelectOption().setLabel(documentCategory));
+        page.selectOption("#cicCaseCaseDocumentsUpload_0_documentCategory", new SelectOption().setLabel(documentCategory));
         String documentName = "sample_A_application_document.pdf";
         page.setInputFiles("input[type='file']", Paths.get("src/e2eTests/java/uk/gov/hmcts/sptribs/testutils/files/" + documentName));
         page.waitForSelector("//span[contains(text(), 'Uploading...')]",
@@ -199,7 +199,7 @@ public class Case {
         page.waitForFunction("selector => document.querySelector(selector).disabled === true",
             "button[aria-label='Cancel upload']", functionOptionsWithTimeout(15000));
         String documentDescription = "This is a test document uploaded during create case journey";
-        page.locator("#cicCaseApplicantDocumentsUpload_0_documentEmailContent").type(documentDescription);
+        page.locator("#cicCaseCaseDocumentsUpload_0_documentEmailContent").type(documentDescription);
         page.locator("//h2[contains(text(), 'File Attachments')]").click();
         clickButton(page, "Continue");
 

--- a/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagement.java
+++ b/src/e2eTests/java/uk/gov/hmcts/sptribs/e2e/DocumentManagement.java
@@ -90,13 +90,13 @@ public class DocumentManagement {
 
     private void uploadDocument(Page page, String documentCategory, String documentDescription, String documentName) {
         clickButton(page, "Add new");
-        page.selectOption("#newCaseworkerCICDocument_0_documentCategory", new SelectOption().setLabel(documentCategory));
+        page.selectOption("#newCaseworkerCICDocumentUpload_0_documentCategory", new SelectOption().setLabel(documentCategory));
         page.setInputFiles("input[type='file']", Paths.get("src/e2eTests/java/uk/gov/hmcts/sptribs/testutils/files/" + documentName));
         page.waitForSelector("//span[contains(text(), 'Uploading...')]",
             new Page.WaitForSelectorOptions().setState(WaitForSelectorState.DETACHED));
         page.waitForFunction("selector => document.querySelector(selector).disabled === true",
             "button[aria-label='Cancel upload']", functionOptionsWithTimeout(15000));
-        page.locator("#newCaseworkerCICDocument_0_documentEmailContent").type(documentDescription);
+        page.locator("#newCaseworkerCICDocumentUpload_0_documentEmailContent").type(documentDescription);
         page.locator("//div[contains(@id, 'newCaseworkerCICDocument')]//h2[contains(text(), 'Documents')]").click();
     }
 }


### PR DESCRIPTION
### Change description ###

Fix for selectors in Create Case document upload

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket has been reviewed by QA
- [ ] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

