### PR TITLE
DTSSTCI 1089 - WA – Duplicate completeHearingOutcome tasks in Demo

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/sptribs/systemupdate/event/SystemTriggerCompleteHearingOutcomeFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/sptribs/systemupdate/event/SystemTriggerCompleteHearingOutcomeFT.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.sptribs.systemupdate.event;
+
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import uk.gov.hmcts.sptribs.testutil.FunctionalTestSuite;
+
+
+import java.util.Map;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.OK;
+import static uk.gov.hmcts.sptribs.systemupdate.event.SystemTriggerCompleteHearingOutcome.SYSTEM_TRIGGER_COMPLETE_HEARING_OUTCOME;
+import static uk.gov.hmcts.sptribs.testutil.CaseDataUtil.caseData;
+import static uk.gov.hmcts.sptribs.testutil.TestConstants.ABOUT_TO_SUBMIT_URL;
+
+@SpringBootTest
+public class SystemTriggerCompleteHearingOutcomeFT extends FunctionalTestSuite{
+    private static final String REQUEST = "classpath:request/casedata/ccd-callback-casedata-general.json";
+
+    @Test
+    public void shouldSetStitchHearingBundleTaskToYesInAboutToSubmit() throws Exception {
+        final Map<String, Object> caseData = caseData(REQUEST);
+        final Response response = triggerCallback(caseData, SYSTEM_TRIGGER_COMPLETE_HEARING_OUTCOME, ABOUT_TO_SUBMIT_URL);
+
+        assertThat(response.getStatusCode()).isEqualTo(OK.value());
+        assertThatJson(response.asString())
+                .inPath("$.data.completeHearingOutcome")
+                .isEqualTo("Yes");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseWorkerCreateHearingSummary.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseWorkerCreateHearingSummary.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.sptribs.caseworker.event.page.HearingTypeAndFormat;
 import uk.gov.hmcts.sptribs.caseworker.event.page.HearingVenues;
 import uk.gov.hmcts.sptribs.caseworker.event.page.SelectHearing;
 import uk.gov.hmcts.sptribs.caseworker.helper.RecordListHelper;
+import uk.gov.hmcts.sptribs.caseworker.model.YesNo;
 import uk.gov.hmcts.sptribs.caseworker.service.HearingService;
 import uk.gov.hmcts.sptribs.caseworker.util.MessageUtil;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
@@ -141,6 +142,7 @@ public class CaseWorkerCreateHearingSummary implements CCDConfig<CaseData, State
 
         hearingService.updateHearingList(caseData, hearingName);
         caseData.getListing().getSummary().setRecFile(new ArrayList<>());
+        caseData.setCompleteHearingOutcomeTask(YesNo.NO);
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(caseData)
             .state(AwaitingOutcome)

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/CaseData.java
@@ -474,6 +474,9 @@ public class CaseData {
     @CCD(access = {DefaultAccess.class, CaseworkerWithCAAAccess.class})
     private YesNo stitchHearingBundleTask;
 
+    @CCD(access = {DefaultAccess.class, CaseworkerWithCAAAccess.class})
+    private YesNo completeHearingOutcomeTask;
+
     @CCD(access = {DefaultAccess.class})
     @JsonUnwrapped
     private RetiredFields retiredFields;

--- a/src/main/java/uk/gov/hmcts/sptribs/systemupdate/event/SystemTriggerCompleteHearingOutcome.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/systemupdate/event/SystemTriggerCompleteHearingOutcome.java
@@ -3,8 +3,11 @@ package uk.gov.hmcts.sptribs.systemupdate.event;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.sptribs.caseworker.model.YesNo;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
 import uk.gov.hmcts.sptribs.ciccase.model.State;
 import uk.gov.hmcts.sptribs.ciccase.model.UserRole;
@@ -36,5 +39,15 @@ public class SystemTriggerCompleteHearingOutcome implements CCDConfig<CaseData, 
             eventBuilder.publishToCamunda()
                     .grant(CREATE_READ_UPDATE, ST_CIC_WA_CONFIG_USER);
         }
+    }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> caseDetails,
+                                                                       CaseDetails<CaseData, State> beforeDetails) {
+        final CaseData caseData = caseDetails.getData();
+        caseData.setCompleteHearingOutcomeTask(YesNo.YES);
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .data(caseData)
+                .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/sptribs/systemupdate/schedule/wa/SystemTriggerCompleteHearingOutcomeTask.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/systemupdate/schedule/wa/SystemTriggerCompleteHearingOutcomeTask.java
@@ -51,6 +51,7 @@ public class SystemTriggerCompleteHearingOutcomeTask implements Runnable {
         try {
             final BoolQueryBuilder query = boolQuery()
                 .must(matchQuery("state", "AwaitingHearing"))
+                .mustNot(matchQuery("data.completeHearingOutcomeTask", "Yes"))
                 .filter(rangeQuery("data.hearingList.value.date").to(LocalDate.now()).from(LocalDate.now()));
 
             final List<CaseDetails> casesNeedsStitchCollateHearingBundle =

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerCreateHearingSummaryTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerCreateHearingSummaryTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 import uk.gov.hmcts.sptribs.caseworker.helper.RecordListHelper;
 import uk.gov.hmcts.sptribs.caseworker.model.HearingSummary;
 import uk.gov.hmcts.sptribs.caseworker.model.Listing;
+import uk.gov.hmcts.sptribs.caseworker.model.YesNo;
 import uk.gov.hmcts.sptribs.caseworker.service.HearingService;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
 import uk.gov.hmcts.sptribs.ciccase.model.CicCase;
@@ -165,6 +166,7 @@ class CaseworkerCreateHearingSummaryTest {
             .isNull();
         assertThat(response.getData().getListing().getSummary().getRecFileUpload()).hasSize(0);
         assertThat(response.getData().getListing().getSummary().getRecFile()).hasSize(0);
+        assertThat(response.getData().getCompleteHearingOutcomeTask()).isEqualTo(YesNo.NO);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/sptribs/systemupdate/event/SystemTriggerCompleteHearingOutcomeTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/systemupdate/event/SystemTriggerCompleteHearingOutcomeTest.java
@@ -6,13 +6,16 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
 import uk.gov.hmcts.sptribs.ciccase.model.State;
 import uk.gov.hmcts.sptribs.ciccase.model.UserRole;
 import uk.gov.hmcts.sptribs.ciccase.model.access.Permissions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.sptribs.caseworker.model.YesNo.YES;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_WA_CONFIG_USER;
 import static uk.gov.hmcts.sptribs.systemupdate.event.SystemTriggerCompleteHearingOutcome.SYSTEM_TRIGGER_COMPLETE_HEARING_OUTCOME;
 import static uk.gov.hmcts.sptribs.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
@@ -65,5 +68,17 @@ class SystemTriggerCompleteHearingOutcomeTest {
                 .extracting(Event::getGrants)
                 .extracting(map -> map.get(ST_CIC_WA_CONFIG_USER))
                 .contains(Permissions.CREATE_READ_UPDATE);
+    }
+
+    @Test
+    void shouldSetStitchHearingBundleTaskToYesInAboutToSubmit() {
+        final CaseData caseData = new CaseData();
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response = systemTriggerCompleteHearingOutcome
+            .aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(response.getData().getCompleteHearingOutcomeTask()).isEqualTo(YES);
     }
 }

--- a/src/test/java/uk/gov/hmcts/sptribs/systemupdate/schedule/wa/SystemTriggerCompleteHearingOutcomeTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/systemupdate/schedule/wa/SystemTriggerCompleteHearingOutcomeTaskTest.java
@@ -58,6 +58,7 @@ class SystemTriggerCompleteHearingOutcomeTaskTest {
 
     private static final BoolQueryBuilder query = boolQuery()
         .must(matchQuery("state", "AwaitingHearing"))
+        .mustNot(matchQuery("data.completeHearingOutcomeTask", "Yes"))
         .filter(rangeQuery("data.hearingList.value.date").to(LocalDate.now()).from(LocalDate.now()));
 
     @BeforeEach


### PR DESCRIPTION
### Change description ###
Add flag and update test for Complete Hearing Outcome to be picked up only once

### JIRA link ###
[DTSSTCI-1089](https://tools.hmcts.net/jira/browse/DTSSTCI-1089)

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

