### PR TITLE
DTSSTCI-1205

### DIFF
--- a/src/main/java/uk/gov/hmcts/sptribs/citizen/event/CicDssUpdateCaseEvent.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/citizen/event/CicDssUpdateCaseEvent.java
@@ -39,6 +39,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.sptribs.caseworker.util.EventConstants.CITIZEN_DSS_UPDATE_CASE_SUBMISSION;
 import static uk.gov.hmcts.sptribs.ciccase.model.State.DSS_Draft;
+import static uk.gov.hmcts.sptribs.ciccase.model.State.DSS_Expired;
 import static uk.gov.hmcts.sptribs.ciccase.model.State.Draft;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.CITIZEN;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.CREATOR;
@@ -58,7 +59,7 @@ import static uk.gov.hmcts.sptribs.ciccase.model.access.Permissions.CREATE_READ_
 @Component
 public class CicDssUpdateCaseEvent implements CCDConfig<CaseData, State, UserRole> {
 
-    private static final EnumSet<State> DSS_UPDATE_CASE_AVAILABLE_STATES = EnumSet.complementOf(EnumSet.of(Draft, DSS_Draft));
+    private static final EnumSet<State> DSS_UPDATE_CASE_AVAILABLE_STATES = EnumSet.complementOf(EnumSet.of(Draft, DSS_Draft, DSS_Expired));
 
     @Autowired
     private DssUpdateCaseSubmissionNotification dssUpdateCaseSubmissionNotification;

--- a/src/main/resources/dmn/wa-task-completion-st_cic-criminalinjuriescompensation.dmn
+++ b/src/main/resources/dmn/wa-task-completion-st_cic-criminalinjuriescompensation.dmn
@@ -561,7 +561,7 @@
       </rule>
       <rule id="DecisionRule_117z5bo">
         <inputEntry id="UnaryTests_1krjzhf">
-          <text>"edit-case","caseworker-case-built","refer-to-judge","refer-to-legal-officer","caseworker-document-management","caseworker-amend-document","create-hearing-summary"</text>
+          <text>"edit-case","caseworker-case-built","refer-to-judge","refer-to-legal-officer","caseworker-document-management","caseworker-amend-document","create-hearing-summary","contact-parties","createBundle"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ahaic3">
           <text></text>

--- a/src/main/resources/dmn/wa-task-completion-st_cic-criminalinjuriescompensation.dmn
+++ b/src/main/resources/dmn/wa-task-completion-st_cic-criminalinjuriescompensation.dmn
@@ -561,7 +561,7 @@
       </rule>
       <rule id="DecisionRule_117z5bo">
         <inputEntry id="UnaryTests_1krjzhf">
-          <text>"edit-case","caseworker-case-built","refer-to-judge","refer-to-legal-officer","caseworker-document-management","caseworker-amend-document","create-hearing-summary","contact-parties","createBundle"</text>
+          <text>"edit-case","caseworker-case-built","refer-to-judge","refer-to-legal-officer","caseworker-document-management","caseworker-amend-document","create-hearing-summary","contact-parties","createBundle","caseworker-amend-due-date"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ahaic3">
           <text></text>

--- a/src/main/resources/dmn/wa-task-initiation-st_cic-criminalinjuriescompensation.dmn
+++ b/src/main/resources/dmn/wa-task-initiation-st_cic-criminalinjuriescompensation.dmn
@@ -1566,10 +1566,10 @@
       </rule>
       <rule id="DecisionRule_1981u5t">
         <inputEntry id="UnaryTests_1o9zfup">
-          <text>"citizen-cic-dss-update-case","caseworker-document-management"</text>
+          <text>"citizen-cic-dss-update-case","caseworker-document-management","respondent-document-management"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1cb1pqu">
-          <text>"CaseManagement"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1j500nm">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/sptribs/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/dmn/CamundaTaskCompletionTest.java
@@ -398,7 +398,8 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", FOLLOW_UP_NONCOMPLIANCE_OF_DIR_TASK,
                         "completionMode", AUTO_COMPLETE_MODE
-                    )
+                    ),
+                    Collections.emptyMap()
                 )
             )
         );

--- a/src/test/java/uk/gov/hmcts/sptribs/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/dmn/CamundaTaskCompletionTest.java
@@ -368,7 +368,8 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", PROCESS_FURTHER_EVIDENCE_TASK,
                         "completionMode", AUTO_COMPLETE_MODE
-                    )
+                    ),
+                    Collections.emptyMap()
                 )
             ),
             Arguments.of(
@@ -377,7 +378,8 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", STITCH_COLLATE_HEARING_BUNDLE_TASK,
                         "completionMode", AUTO_COMPLETE_MODE
-                    )
+                    ),
+                    Collections.emptyMap()
                 )
             ),
             Arguments.of(

--- a/src/test/java/uk/gov/hmcts/sptribs/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/dmn/CamundaTaskWaInitiationTest.java
@@ -828,7 +828,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
             ),
             Arguments.of(
                 "citizen-cic-dss-update-case",
-                "CaseManagement",
+                "*",
                 null,
                 List.of(
                     Map.of(
@@ -843,7 +843,22 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
             ),
             Arguments.of(
                 "caseworker-document-management",
-                "CaseManagement",
+                "*",
+                null,
+                List.of(
+                    Map.of(
+                        "taskId", PROCESS_FURTHER_EVIDENCE_TASK,
+                        "name", "Process further evidence",
+                        "workingDaysAllowed", 7,
+                        "processCategories", PROCESS_CATEGORY_PROCESSING,
+                        "workType", ROUTINE_WORK_TYPE,
+                        "roleCategory", ROLE_CATEGORY_ADMIN
+                    )
+                )
+            ),
+            Arguments.of(
+                "respondent-document-management",
+                "*",
                 null,
                 List.of(
                     Map.of(


### PR DESCRIPTION
### Change description ###
Update DMN initiation and completion rules

- processFurtherEvidence task initiated if "citizen-cic-dss-update-case", "caseworker-document-management" and "respondent-document-management" events submitted and the post event state is ANY.
- Made taskless: createBundle, contact-parties

### JIRA link ###
https://tools.hmcts.net/jira/browse/DTSSTCI-1205