### PR TITLE
Remove reference to hmctsprivatetemp

### DIFF
--- a/charts/sptribs-case-api/values.wa.preview.template.yaml
+++ b/charts/sptribs-case-api/values.wa.preview.template.yaml
@@ -45,7 +45,7 @@ wa:
 
   camunda-bpm:
     java:
-      image: hmctsprivatetemp.azurecr.io/camunda/bpm:latest
+      image: hmctsprivate.azurecr.io/camunda/bpm:latest
 
   wa-case-event-handler:
     java:


### PR DESCRIPTION
### Change description ###
- Removing the reference the the temporary container registry that  is going to be deleted.
- Replaced with original `hmctsprivate` registry

### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSPO-24378

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket has been reviewed by QA
- [ ] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

