### PR TITLE
[DTSSTCI-1263] Upgrade Java and Servicebus to OCI Charts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '3.2.5'
   id 'com.github.ben-manes.versions' version '0.50.0'
-  id 'hmcts.ccd.sdk' version '5.5.18'
+  id 'hmcts.ccd.sdk' version '5.5.16'
   id "au.com.dius.pact" version "4.3.10"
   id 'com.github.hmcts.rse-cft-lib' version '0.19.1534'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -328,7 +328,6 @@ dependencies {
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
   implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.9.2'
-//  implementation group: 'com.github.hmcts', name: 'ccd-config-generator', version: '5.5.18'
   implementation group: 'com.github.hmcts', name:'ccd-case-document-am-client', version: '1.59'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.3'
   implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '3.2.5'
   id 'com.github.ben-manes.versions' version '0.50.0'
-  id 'hmcts.ccd.sdk' version '5.5.16'
+  id 'hmcts.ccd.sdk' version '5.5.18'
   id "au.com.dius.pact" version "4.3.10"
   id 'com.github.hmcts.rse-cft-lib' version '0.19.1534'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -329,6 +329,7 @@ dependencies {
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
   implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.9.2'
+  implementation group: 'com.github.hmcts', name: 'ccd-config-generator', version: '5.5.18'
   implementation group: 'com.github.hmcts', name:'ccd-case-document-am-client', version: '1.59'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.3'
   implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '3.2.5'
   id 'com.github.ben-manes.versions' version '0.50.0'
-  id 'hmcts.ccd.sdk' version '5.5.16'
+  id 'hmcts.ccd.sdk' version '5.5.19'
   id "au.com.dius.pact" version "4.3.10"
   id 'com.github.hmcts.rse-cft-lib' version '0.19.1534'
 }
@@ -329,7 +329,7 @@ dependencies {
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
   implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.9.2'
-  implementation group: 'com.github.hmcts', name: 'ccd-config-generator', version: '5.5.18'
+//  implementation group: 'com.github.hmcts', name: 'ccd-config-generator', version: '5.5.18'
   implementation group: 'com.github.hmcts', name:'ccd-case-document-am-client', version: '1.59'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.3'
   implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.1.7'

--- a/charts/sptribs-case-api/Chart.yaml
+++ b/charts/sptribs-case-api/Chart.yaml
@@ -53,7 +53,7 @@ dependencies:
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: wa.enabled
   - name: servicebus
-    version: ~1.1.0
+    version: ~1.2.0
     repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: servicebus.enabled
   - name: postgresql

--- a/charts/sptribs-case-api/Chart.yaml
+++ b/charts/sptribs-case-api/Chart.yaml
@@ -11,56 +11,56 @@ dependencies:
     version: 5.3.0
     repository: 'oci://hmctspublic.azurecr.io/helm'
   - name: ccd
-    version: 9.2.1
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    version: 9.2.2
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     tags:
       - ccd-idam-pr
   - name: xui-webapp
     version: ~1.0.0
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: xui-webapp.enabled
   - name: xui-mo-webapp
     version: ~1.1.0
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: xui-mo-webapp.enabled
   - name: aac-manage-case-assignment
     version: ~0.2.0
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: aac-manage-case-assignment.enabled
   - name: idam-pr
     version: 2.3.0
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: idam-pr.enabled
   - name: ccd-case-document-am-api
     version: 1.7.14
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io'
     condition: ccd-case-document-am-api.enabled
   - name: em-ccdorc
     version: 2.0.25
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: em-ccdorc.enabled
   - name: em-stitching
     version: 1.0.55
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: em-stitching.enabled
 #    Work Allocation
   - name: wa
-    version: ~1.0.5
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    version: ~1.1.0
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: wa.enabled
   - name: ccd-message-publisher
     version: ~0.1.7
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: wa.enabled
   - name: servicebus
     version: ~1.2.0
     repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: servicebus.enabled
   - name: postgresql
-    version: ~1.0.2
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    version: ~1.1.0
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: postgresql.enabled
   - name: am-org-role-mapping-service
     version: ~0.0.66
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: am-org-role-mapping-service.enabled

--- a/charts/sptribs-case-api/Chart.yaml
+++ b/charts/sptribs-case-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for sptribs-case-api App
 name: sptribs-case-api
 home: https://github.com/hmcts/sptribs-case-api
-version: 0.0.103
+version: 0.0.104
 maintainers:
   - name: HMCTS sptribs team
 dependencies:

--- a/charts/sptribs-case-api/Chart.yaml
+++ b/charts/sptribs-case-api/Chart.yaml
@@ -32,7 +32,7 @@ dependencies:
     repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: idam-pr.enabled
   - name: ccd-case-document-am-api
-    version: 1.7.14
+    version: 1.7.16
     repository: 'oci://hmctspublic.azurecr.io'
     condition: ccd-case-document-am-api.enabled
   - name: em-ccdorc

--- a/charts/sptribs-case-api/Chart.yaml
+++ b/charts/sptribs-case-api/Chart.yaml
@@ -32,8 +32,8 @@ dependencies:
     repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: idam-pr.enabled
   - name: ccd-case-document-am-api
-    version: 1.7.16
-    repository: 'oci://hmctspublic.azurecr.io'
+    version: 1.7.14
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd-case-document-am-api.enabled
   - name: em-ccdorc
     version: 2.0.25

--- a/charts/sptribs-case-api/Chart.yaml
+++ b/charts/sptribs-case-api/Chart.yaml
@@ -3,13 +3,13 @@ appVersion: "1.0"
 description: A Helm chart for sptribs-case-api App
 name: sptribs-case-api
 home: https://github.com/hmcts/sptribs-case-api
-version: 0.0.100
+version: 0.0.101
 maintainers:
   - name: HMCTS sptribs team
 dependencies:
   - name: java
-    version: 5.2.1
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    version: 5.3.0
+    repository: 'oci://hmctspublic.azurecr.io/helm'
   - name: ccd
     version: 9.2.1
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/charts/sptribs-case-api/Chart.yaml
+++ b/charts/sptribs-case-api/Chart.yaml
@@ -53,8 +53,8 @@ dependencies:
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: wa.enabled
   - name: servicebus
-    version: ~1.0.6
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    version: ~1.1.0
+    repository: 'oci://hmctspublic.azurecr.io/helm'
     condition: servicebus.enabled
   - name: postgresql
     version: ~1.0.2


### PR DESCRIPTION
### Change description ###
Upgrade Java Chart version to OCI 5.3.0 and Servicebus version to OCI 1.1.0

### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSSTCI-1263

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket has been reviewed by QA
- [ ] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

