### PR TITLE
Test dependencies/vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,3 @@ TASK_NAME=SystemProgressHeldCasesTask ./gradlew bootRun
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-

--- a/build.gradle
+++ b/build.gradle
@@ -335,8 +335,8 @@ dependencies {
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.4'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.0'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.22.0'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.34'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.34'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.40'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.40'
   implementation group: 'org.elasticsearch', name: 'elasticsearch' , version: '7.17.27'
   implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.3.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,8 +8,4 @@
     <cve>CVE-2024-45772</cve>
     <cpe>cpe:2.3:a:apache:lucene:8.11.3:*:*:*:*:*:*:*</cpe>
   </suppress>
-   <suppress>
-    <cve>CVE-2025-24813</cve>
-    <cpe>cpe:2.3:a:apache_tomcat:apache_tomcat:10.1.34:*:*:*:*:*:*:*</cpe>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###
Update apache.tomcat dependencies to fix vulnerabilities in CVE-2025-31650 and CVE-2025-31651

