### PR TITLE
DTSSTCI-1353: Remove CAMUNDA_BASE_URL from values.yaml

### DIFF
--- a/charts/sptribs-case-api/values.yaml
+++ b/charts/sptribs-case-api/values.yaml
@@ -82,6 +82,5 @@ java:
     SERVICE_AUTH_PROVIDER_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     NOTIFY_TEMPLATE_SIGN_IN_PROFESSIONAL_USERS_URL: https://manage-case.{{ .Values.global.environment }}.platform.hmcts.net/cases/case-details/
     S2S_AUTHORISED_SERVICES: ccd_definition,ccd_data,xui_webapp,sptribs_case_api,ccd_gw,sptribs_frontend,sptribs_dss_update_case_web
-    CAMUNDA_BASE_URL: http://camunda-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
 
     WA_FEATURE_ENABLED: true


### PR DESCRIPTION
### Change description ###
Removes CAMUNDA_BASE_URL from values.yaml because the app doesn't use it (it's just needed in the pipeline).

### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSSTCI-1353