### PR TITLE
SNI-6983 - Add new access profile for restricting resp access to case notes

### DIFF
--- a/src/cftlib/java/uk/gov/hmcts/sptribs/cftlib/CftLibConfig.java
+++ b/src/cftlib/java/uk/gov/hmcts/sptribs/cftlib/CftLibConfig.java
@@ -72,7 +72,8 @@ public class CftLibConfig implements CFTLibConfigurer {
             "citizen",
             "caseworker-wa-task-configuration",
             "GS_profile",
-            "caseworker-ras-validation"
+            "caseworker-ras-validation",
+            "caseworker-sptribs-privileged-user"
         );
 
         ResourceLoader resourceLoader = new DefaultResourceLoader();

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/UserRole.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/UserRole.java
@@ -25,6 +25,7 @@ public enum UserRole implements HasRole {
     ST_CIC_HEARING_CENTRE_ADMIN("caseworker-st_cic-hearing-centre-admin", "CRU"),
     ST_CIC_HEARING_CENTRE_TEAM_LEADER("caseworker-st_cic-hearing-centre-team-leader", "CRU"),
     ST_CIC_SENIOR_JUDGE("caseworker-st_cic-senior-judge", "CRU"),
+    CIC_PRIVILEGED_USER("caseworker-sptribs-privileged-user", "R"),
 
     ST_CIC_JUDGE("caseworker-st_cic-judge", "CRU"),
     ST_CIC_RESPONDENT("caseworker-st_cic-respondent", "CRU"),

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/UserRolesForAccessProfiles.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/UserRolesForAccessProfiles.java
@@ -26,6 +26,8 @@ public enum UserRolesForAccessProfiles implements HasRole {
 
     // Below are the Access Profiles for the Idam Roles
     CIC_SUPER_USER("caseworker-sptribs-superuser", "CRU"),
+    //Privileged Granted to all users who are allowed to read privileged tabs (in essence this is everyone except the respondent)
+    CIC_PRIVILEGED_USER("caseworker-sptribs-privileged-user", "R"),
     AC_SYSTEMUPDATE("caseworker-sptribs-systemupdate", "CRU"),
     CIC_CASEWORKER("caseworker-st_cic-caseworker", "CRU"),
     CIC_SENIOR_CASEWORKER("caseworker-st_cic-senior-caseworker", "CRU"),

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/accessprofile/CICAccessProfile.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/model/accessprofile/CICAccessProfile.java
@@ -19,31 +19,38 @@ public class CICAccessProfile implements CCDConfig<CriminalInjuriesCompensationD
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.SUPER_USER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_SUPER_USER.getRole(),
                 UserRolesForAccessProfiles.GS_PROFILE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ST_CIC_CASEWORKER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CASEWORKER.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ST_CIC_SENIOR_CASEWORKER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_CASEWORKER.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ST_CIC_HEARING_CENTRE_ADMIN)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_ADMIN.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ST_CIC_HEARING_CENTRE_TEAM_LEADER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ST_CIC_SENIOR_JUDGE)
             .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ST_CIC_JUDGE)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ST_CIC_RESPONDENT)
             .accessProfiles(UserRolesForAccessProfiles.CIC_RESPONDENT.getRole())
@@ -60,50 +67,64 @@ public class CICAccessProfile implements CCDConfig<CriminalInjuriesCompensationD
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.SYSTEMUPDATE)
             .accessProfiles(UserRolesForAccessProfiles.AC_SYSTEMUPDATE.getRole(),
                 UserRolesForAccessProfiles.GS_PROFILE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_HMCTS_STAFF)
-            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_HMCTS_CTSC)
-            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_HMCTS_LEGAL_OPERATIONS)
-            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_HMCTS_ADMIN)
-            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_HMCTS_JUDICIARY)
-            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SPECIFIC_ACCESS_APPROVER_LEGAL_OPS)
             .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
-                UserRolesForAccessProfiles.CIC_SENIOR_CASEWORKER.getRole())
+                UserRolesForAccessProfiles.CIC_SENIOR_CASEWORKER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SPECIFIC_ACCESS_APPROVER_CTSC)
             .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
-                UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole())
+                UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SPECIFIC_ACCESS_APPROVER_ADMIN)
             .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
-                UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole())
+                UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SPECIFIC_ACCESS_APPROVER_JUDICIARY)
             .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole(),
-                UserRolesForAccessProfiles.CIC_SENIOR_JUDGE.getRole())
+                UserRolesForAccessProfiles.CIC_SENIOR_JUDGE.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SPECIFIC_ACCESS_LEGAL_OPS)
-            .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_CASEWORKER.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_CASEWORKER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SPECIFIC_ACCESS_CTSC)
-            .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SPECIFIC_ACCESS_ADMIN)
-            .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SPECIFIC_ACCESS_JUDICIARY)
-            .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_JUDGE.getRole())
+            .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_JUDGE.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_TASK_SUPERVISOR)
             .accessProfiles(UserRolesForAccessProfiles.GS_PROFILE.getRole())
@@ -113,103 +134,129 @@ public class CICAccessProfile implements CCDConfig<CriminalInjuriesCompensationD
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SENIOR_TRIBUNAL_CASEWORKER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_CASEWORKER.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_TRIBUNAL_CASEWORKER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CASEWORKER.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_REGIONAL_CENTRE_TEAM_LEADER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_HEARING_CENTRE_TEAM_LEADER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_CTSC_TEAM_LEADER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_TEAM_LEADER.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_REGIONAL_CENTRE_ADMIN)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_ADMIN.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_HEARING_CENTRE_ADMIN)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_ADMIN.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_CTSC)
             .accessProfiles(UserRolesForAccessProfiles.CIC_CENTRE_ADMIN.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_CICA)
             .accessProfiles(UserRolesForAccessProfiles.CIC_RESPONDENT.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_ADMIN.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_SENIOR_JUDGE)
             .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_LEADERSHIP_JUDGE)
             .accessProfiles(UserRolesForAccessProfiles.CIC_SENIOR_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_FEE_PAID_JUDGE)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_JUDGE)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_FEE_PAID_TRIBUNAL_MEMBER)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_MEDICAL)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_FEE_PAID_MEDICAL)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_FEE_PAID_DISABILITY)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_FEE_PAID_FINANCIAL)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_ALLOCATED_JUDGE)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_INTERLOC_JUDGE)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_TRIBUNAL_MEMBER1)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_TRIBUNAL_MEMBER2)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_TRIBUNAL_MEMBER3)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_APPRAISER1)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.RAS_ST_APPRAISER2)
             .accessProfiles(UserRolesForAccessProfiles.CIC_JUDGE.getRole(),
-                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole())
+                UserRolesForAccessProfiles.AC_CASEFLAGS_VIEWER.getRole(),
+                UserRolesForAccessProfiles.CIC_PRIVILEGED_USER.getRole())
             .build();
         configBuilder.caseRoleToAccessProfile(UserRolesForAccessProfiles.ST_CIC_WA_CONFIG_USER)
             .accessProfiles(UserRolesForAccessProfiles.AC_ST_CIC_WA_CONFIG_USER.getRole())

--- a/src/main/java/uk/gov/hmcts/sptribs/ciccase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/ciccase/tab/CaseTypeTab.java
@@ -9,13 +9,12 @@ import uk.gov.hmcts.sptribs.ciccase.model.State;
 import uk.gov.hmcts.sptribs.ciccase.model.UserRole;
 
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.AC_CASE_FLAGS_VIEWER;
+import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.CASEWORKER;
+import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.CIC_PRIVILEGED_USER;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_CASEWORKER;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_HEARING_CENTRE_ADMIN;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_HEARING_CENTRE_TEAM_LEADER;
-import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_JUDGE;
-import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_RESPONDENT;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_SENIOR_CASEWORKER;
-import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_SENIOR_JUDGE;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.sptribs.ciccase.search.CaseFieldsConstants.APPLICANT_ADDRESS;
 import static uk.gov.hmcts.sptribs.ciccase.search.CaseFieldsConstants.APPLICANT_CONTACT_PREFERENCE;
@@ -96,8 +95,8 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
     private void buildCaseFlagTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("caseFlags", "Case Flags")
             .forRoles(AC_CASE_FLAGS_VIEWER, SUPER_USER,
-                    ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                    ST_CIC_HEARING_CENTRE_TEAM_LEADER)
+                ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
+                ST_CIC_HEARING_CENTRE_TEAM_LEADER)
             .field(CaseData::getFlagLauncher, null, "#ARGUMENT(READ)")
             .field(CaseData::getCaseFlags, COND_ALWAYS_HIDE_STAY_REASON)
             .field(CaseData::getSubjectFlags, COND_ALWAYS_HIDE_STAY_REASON)
@@ -107,8 +106,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildCaseLinkTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("caseLinks", "Linked cases")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(AC_CASE_FLAGS_VIEWER, CASEWORKER)
             .field(CaseData::getLinkedCasesComponentLauncher, null, "#ARGUMENT(LinkedCases)")
             .field(CaseData::getCaseNameHmctsInternal, COND_ALWAYS_HIDE_STAY_REASON, null)
             .field(CaseData::getCaseLinks, "LinkedCasesComponentLauncher!=\"\"", "#ARGUMENT(LinkedCases)");
@@ -116,15 +114,13 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildCaseFileViewTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("caseFileView", "Case file view")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .field(CaseData::getCaseFileView1, null, "#ARGUMENT(CaseFileView)");
     }
 
     private void buildSummaryTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("summary", "Summary")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label(CASE_STATE_LABEL, null, "#### Case Status:  ${[STATE]}")
             .label(CASE_DETAILS, null, "### Case details")
             .field(SUBJECT_NAME)
@@ -153,36 +149,31 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildStateTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("state", "State")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label(CASE_STATE_LABEL, null, "#### Case State:  ${[STATE]}");
     }
 
     private void buildNotesTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("notes", "Notes")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, SUPER_USER)
+            .forRoles(CIC_PRIVILEGED_USER)
             .field(CaseData::getNotes);
     }
 
     private void buildBundlesTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("bundles", "Bundles")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .field(CaseData::getCaseBundles);
     }
 
     private void buildMessagesTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("messages", "Messages")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .field(CaseData::getMessages);
     }
 
     private void buildCaseDetailsTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("caseDetails", "Case Details")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label(CASE_DETAILS, null, "### Case details")
             .field(CASE_CATEGORY)
             .field(CASE_RECEIVED_DATE)
@@ -222,8 +213,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildCasePartiesTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("caseParties", "Case Parties")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label("Subject's details", null, "### Subject's details")
             .field(SUBJECT_NAME)
             .field(SUBJECT_EMAIL)
@@ -256,8 +246,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildOrderTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("orders", "Orders & Decisions")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label("Orders", null, "### Orders")
             .label(CASE_STATE_LABEL, null, "#### Case Status: ${[STATE]}")
             .field("cicCaseDraftOrderCICList")
@@ -272,8 +261,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildCaseDocumentTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("caseDocuments", "Case Documents")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label("Case Documents", null, "#### Case Documents")
             .field("cicCaseApplicantDocumentsUploaded")
             .field("allCaseworkerCICDocument");
@@ -281,16 +269,14 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildCicaDetails(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("cicaDetails", "CICA Details")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label("CICA Details", null, "#### CICA Details")
             .field(CaseData::getEditCicaCaseDetails);
     }
 
     private void buildHearing(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("hearings", "Hearings")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label("Listing details", COND_HEARING_LIST_NOT_ANY_AND_HEARING_TYPE_NOT_EMPTY, "#### Listing details")
             .field("hearingCreatedDate", COND_HEARING_LIST_NOT_ANY_AND_CANCELLATION_REASON_NOT_EMPTY)
             .field("hearingStatus", COND_HEARING_LIST_NOT_ANY_AND_HEARING_TYPE_NOT_EMPTY)
@@ -347,8 +333,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildCaseReferralTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("caseReferrals", "Case Referrals")
-            .forRoles(ST_CIC_CASEWORKER, ST_CIC_SENIOR_CASEWORKER, ST_CIC_HEARING_CENTRE_ADMIN,
-                ST_CIC_HEARING_CENTRE_TEAM_LEADER, ST_CIC_SENIOR_JUDGE, ST_CIC_JUDGE, ST_CIC_RESPONDENT, SUPER_USER)
+            .forRoles(CASEWORKER)
             .label("Referral to Judge", null, "#### Referral to Judge")
             .field("referToJudgeReferralReason")
             .field("referToJudgeReasonForReferral")


### PR DESCRIPTION
### Change description ###
Ultimate goal is to remove duplicate tabs - last time this was attempted it had to be reverted because some tabs are privileged and not meant to be viewable by respondents, and the role that was chosen belonged to respondents also. Therefore created a new Access Profile that has been added to all idam roles except citizen and respondent to circumvent the issue

### JIRA link ###

https://tools.hmcts.net/jira/browse/SNI-6983

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket has been reviewed by QA
- [ ] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

