### PR TITLE
[DTSSTCI-1414] Update send order event to be taskless

### DIFF
--- a/src/main/resources/dmn/wa-task-completion-st_cic-criminalinjuriescompensation.dmn
+++ b/src/main/resources/dmn/wa-task-completion-st_cic-criminalinjuriescompensation.dmn
@@ -715,7 +715,7 @@
       </rule>
       <rule id="DecisionRule_117z5bo">
         <inputEntry id="UnaryTests_1krjzhf">
-          <text>"edit-case","caseworker-case-built","refer-to-judge","refer-to-legal-officer","caseworker-document-management","caseworker-amend-document","create-hearing-summary","contact-parties","createBundle","caseworker-amend-due-date","create-draft-order","caseworker-issue-final-decision","caseworker-issue-decision"</text>
+          <text>"edit-case","caseworker-case-built","refer-to-judge","refer-to-legal-officer","caseworker-document-management","caseworker-amend-document","create-hearing-summary","contact-parties","createBundle","caseworker-amend-due-date","create-draft-order","caseworker-send-order","caseworker-issue-final-decision","caseworker-issue-decision"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ahaic3">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/sptribs/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/dmn/CamundaTaskCompletionTest.java
@@ -177,7 +177,8 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", ISSUE_DUE_DATE,
                         "completionMode", AUTO_COMPLETE_MODE
-                    )
+                    ),
+                    Collections.emptyMap()
                 )
             ),
             Arguments.of(


### PR DESCRIPTION
### Change description ###
Make the send order event taskless - so that I can be performed on a case when no tasks are present

### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSSTCI-1414

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket has been reviewed by QA
- [ ] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

