### PR TITLE
sdk-upgrade-fix: upgrade from 6.6.2 to 6.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '3.5.10'
   id 'com.github.ben-manes.versions' version '0.50.0'
-  id 'hmcts.ccd.sdk' version '6.6.2'
+  id 'hmcts.ccd.sdk' version '6.6.3'
   id "au.com.dius.pact" version "4.3.10"
   id 'com.github.hmcts.rse-cft-lib' version '0.19.2017'
 }


### PR DESCRIPTION
### Change description ###
In build.gradle, upgrade hmcts.ccd.sdk to version 6.6.3 so that bootWithCCD can be run locally