### PR TITLE
[DTSSTCI-1758] Add dates for orders, decisions and final decisions when converted to CaseworkerCICDocuments

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerIssueDecisionFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerIssueDecisionFT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import uk.gov.hmcts.sptribs.testutil.FunctionalTestSuite;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -32,6 +33,7 @@ public class CaseworkerIssueDecisionFT extends FunctionalTestSuite {
     private static final String RESPONSE_MID_EVENT = "classpath:responses/response-caseworker-issue-decision-mid-event.json";
 
     private static final String DECISION_SIGNATURE = "$.data.decisionSignature";
+    private static final String DECISION_DATE = "$.data.caseIssueFinalDecisionFinalDecisionDate";
     private static final String STATE = "$.state";
     private static final String CONFIRMATION_HEADER = "$.confirmation_header";
 
@@ -68,6 +70,19 @@ public class CaseworkerIssueDecisionFT extends FunctionalTestSuite {
             .inPath(STATE)
             .isString()
             .isEqualTo("CaseManagement");
+    }
+
+    @Test
+    public void shouldAddDateWhenAboutToSubmitEventCallbackIsInvoked() throws Exception {
+        final Map<String, Object> caseData = caseData(CALLBACK_REQUEST);
+        final Response response = triggerCallback(caseData, CASEWORKER_ISSUE_DECISION, ABOUT_TO_SUBMIT_URL);
+
+        assertThat(response.getStatusCode()).isEqualTo(OK.value());
+        assertThatJson(response.asString())
+                .inPath(DECISION_DATE)
+                .isString()
+                .isEqualTo(LocalDate.now().toString());
+
     }
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerIssueDecisionFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerIssueDecisionFT.java
@@ -33,7 +33,7 @@ public class CaseworkerIssueDecisionFT extends FunctionalTestSuite {
     private static final String RESPONSE_MID_EVENT = "classpath:responses/response-caseworker-issue-decision-mid-event.json";
 
     private static final String DECISION_SIGNATURE = "$.data.decisionSignature";
-    private static final String DECISION_DATE = "$.data.caseIssueFinalDecisionFinalDecisionDate";
+    private static final String DECISION_DATE = "$.data.caseIssueDecisionDecisionDate";
     private static final String STATE = "$.state";
     private static final String CONFIRMATION_HEADER = "$.confirmation_header";
 

--- a/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerIssueFinalDecisionFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/sptribs/caseworker/CaseworkerIssueFinalDecisionFT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import uk.gov.hmcts.sptribs.testutil.FunctionalTestSuite;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -36,6 +37,7 @@ public class CaseworkerIssueFinalDecisionFT extends FunctionalTestSuite {
     private static final String RESPONSE_MID_EVENT = "classpath:responses/response-caseworker-issue-final-decision-mid-event.json";
 
     private static final String DECISION_SIGNATURE = "$.data.decisionSignature";
+    private static final String DECISION_DATE = "$.data.caseIssueFinalDecisionFinalDecisionDate";
     private static final String STATE = "$.state";
     private static final String CONFIRMATION_HEADER = "$.confirmation_header";
 
@@ -84,6 +86,18 @@ public class CaseworkerIssueFinalDecisionFT extends FunctionalTestSuite {
             .inPath(STATE)
             .isString()
             .isEqualTo("CaseClosed");
+    }
+
+    @Test
+    public void shouldAddDateWhenAboutToSubmitEventCallbackIsInvoked() throws Exception {
+        final Map<String, Object> caseData = caseData(CALLBACK_REQUEST);
+        final Response response = triggerCallback(caseData, CASEWORKER_ISSUE_FINAL_DECISION, ABOUT_TO_SUBMIT_URL);
+
+        assertThat(response.getStatusCode()).isEqualTo(OK.value());
+        assertThatJson(response.asString())
+                .inPath(DECISION_DATE)
+                .isString()
+                .isEqualTo(LocalDate.now().toString());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueDecisionIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueDecisionIT.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.reform.idam.client.models.User;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
@@ -42,7 +43,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.sptribs.ciccase.model.ApplicantCIC.APPLICANT_CIC;
 import static uk.gov.hmcts.sptribs.ciccase.model.ContactPreferenceType.EMAIL;
@@ -66,7 +66,7 @@ import static uk.gov.hmcts.sptribs.testutil.TestResourceUtil.expectedResponse;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @ContextConfiguration(initializers = {IdamWireMock.PropertiesInitializer.class})
-public class CaseWorkerIssueDecisionIT {
+public class CaseworkerIssueDecisionIT {
     private static final String CASEWORKER_ISSUE_DECISION_MID_EVENT_RESPONSE =
         "classpath:responses/caseworker-issue-decision-mid-event-response.json";
     private static final String CASEWORKER_ISSUE_DECISION_ABOUT_TO_SUBMIT_RESPONSE =
@@ -128,7 +128,7 @@ public class CaseWorkerIssueDecisionIT {
 
     @Test
     void shouldRenderDocumentInMidEvent() throws Exception {
-        final CaseIssueDecision caseIssueDecision = new CaseIssueDecision().builder()
+        final CaseIssueDecision caseIssueDecision = CaseIssueDecision.builder()
             .issueDecisionTemplate(DecisionTemplate.ELIGIBILITY)
             .build();
 
@@ -143,7 +143,7 @@ public class CaseWorkerIssueDecisionIT {
                 .build()
         );
 
-        Document document = new Document().builder()
+        Document document = Document.builder()
             .url("url")
             .binaryUrl("binary url")
             .filename("filename")
@@ -197,7 +197,7 @@ public class CaseWorkerIssueDecisionIT {
             .documentLink(Document.builder().url("url").binaryUrl("binary").filename("filename").build())
             .build();
 
-        final CaseIssueDecision caseIssueDecision = new CaseIssueDecision().builder()
+        final CaseIssueDecision caseIssueDecision = CaseIssueDecision.builder()
             .decisionDocument(document)
             .build();
 
@@ -205,7 +205,7 @@ public class CaseWorkerIssueDecisionIT {
             .caseIssueDecision(caseIssueDecision)
             .build();
 
-        mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
+        MvcResult result = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
                 .contentType(APPLICATION_JSON)
                 .header(SERVICE_AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
                 .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
@@ -216,9 +216,10 @@ public class CaseWorkerIssueDecisionIT {
                 .accept(APPLICATION_JSON))
             .andExpect(
                 status().isOk())
-            .andExpect(
-                content().json(expectedResponse(CASEWORKER_ISSUE_DECISION_ABOUT_TO_SUBMIT_RESPONSE))
-            );
+            .andReturn();
+
+        String actualResponse = result.getResponse().getContentAsString();
+        assertThatJson(actualResponse).isEqualTo(expectedResponse(CASEWORKER_ISSUE_DECISION_ABOUT_TO_SUBMIT_RESPONSE));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecisionIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecisionIT.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.reform.idam.client.models.User;
@@ -239,7 +240,7 @@ public class CaseworkerIssueFinalDecisionIT {
             .caseIssueFinalDecision(caseIssueFinalDecision)
             .build();
 
-        mockMvc.perform(MockMvcRequestBuilders.post(ABOUT_TO_SUBMIT_URL)
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post(ABOUT_TO_SUBMIT_URL)
                 .contentType(APPLICATION_JSON)
                 .header(TestConstants.SERVICE_AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
                 .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
@@ -250,9 +251,10 @@ public class CaseworkerIssueFinalDecisionIT {
                 .accept(APPLICATION_JSON))
             .andExpect(
                 status().isOk())
-            .andExpect(
-                content().json(expectedResponse(CASEWORKER_ISSUE_FINAL_DECISION_ABOUT_TO_SUBMIT_RESPONSE))
-            );
+            .andReturn();
+
+        String actualResponse = result.getResponse().getContentAsString();
+        assertThatJson(actualResponse).isEqualTo(expectedResponse(CASEWORKER_ISSUE_FINAL_DECISION_ABOUT_TO_SUBMIT_RESPONSE));
     }
 
     @Test

--- a/src/integrationTest/resources/responses/caseworker-issue-decision-about-to-submit-response.json
+++ b/src/integrationTest/resources/responses/caseworker-issue-decision-about-to-submit-response.json
@@ -1,5 +1,22 @@
 {
   "data": {
+    "caseLinks": [],
+    "allCaseworkerCICDocument": [],
+    "allCaseworkerCICDocumentUpload": [],
+    "newCaseworkerCICDocument": [],
+    "newCaseworkerCICDocumentUpload": [],
+    "editCicaCaseDetails": {},
+    "contactParties": {},
+    "caseBundles": [],
+    "caseBundleIdsAndTimestamps": [],
+    "cicCaseRespondentName": "Appeals team",
+    "cicCaseRespondentOrganisation": "CICA",
+    "cicCaseRespondentEmail": "appeals.team@cica.gov.uk",
+    "cicCaseAlternativeRespondentEmail": "notice.appeals@cica.gov.uk",
+    "orderDueDates": [],
+    "stayIsCaseStayed": "No",
+    "hearingList": [],
+    "closedDayCount": "",
     "caseIssueDecisionDecisionDocument": {
       "documentLink": {
         "document_url": "url",
@@ -7,7 +24,11 @@
         "document_binary_url": "binary",
         "category_id": "TD"
       }
-    }
+    },
+    "caseIssueDecisionDecisionDate": "${json-unit.regex}^\\d{4}-\\d{2}-\\d{2}$",
+    "firstHearingDate": "",
+    "dataVersion": 0,
+    "cicCaseSelectedDocument": {}
   },
   "state": "CaseManagement"
 }

--- a/src/integrationTest/resources/responses/caseworker-issue-final-decision-about-to-submit-response.json
+++ b/src/integrationTest/resources/responses/caseworker-issue-final-decision-about-to-submit-response.json
@@ -1,13 +1,34 @@
 {
-  "data": {
-    "caseIssueFinalDecisionDocument": {
-      "documentLink": {
-        "document_url": "url",
-        "document_filename": "filename.pdf",
-        "document_binary_url": "binary",
-        "category_id": "TD"
+  "data" : {
+    "caseLinks" : [ ],
+    "allCaseworkerCICDocument" : [ ],
+    "allCaseworkerCICDocumentUpload" : [ ],
+    "newCaseworkerCICDocument" : [ ],
+    "newCaseworkerCICDocumentUpload" : [ ],
+    "editCicaCaseDetails" : { },
+    "contactParties" : { },
+    "caseBundles" : [ ],
+    "caseBundleIdsAndTimestamps" : [ ],
+    "cicCaseRespondentName" : "Appeals team",
+    "cicCaseRespondentOrganisation" : "CICA",
+    "cicCaseRespondentEmail" : "appeals.team@cica.gov.uk",
+    "cicCaseAlternativeRespondentEmail" : "notice.appeals@cica.gov.uk",
+    "orderDueDates" : [ ],
+    "stayIsCaseStayed" : "No",
+    "hearingList" : [ ],
+    "closedDayCount" : "",
+    "caseIssueFinalDecisionDocument" : {
+      "documentLink" : {
+        "document_url" : "url",
+        "document_filename" : "filename.pdf",
+        "document_binary_url" : "binary",
+        "category_id" : "TD"
       }
-    }
+    },
+    "caseIssueFinalDecisionFinalDecisionDate": "${json-unit.regex}^\\d{4}-\\d{2}-\\d{2}$",
+    "firstHearingDate" : "",
+    "dataVersion" : 0,
+    "cicCaseSelectedDocument" : { }
   },
-  "state": "CaseClosed"
+  "state" : "CaseClosed"
 }

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueDecision.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueDecision.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.sptribs.caseworker.event;
 
-import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
@@ -10,7 +9,6 @@ import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
-import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueDecisionMainContent;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueDecisionNotice;
@@ -18,25 +16,20 @@ import uk.gov.hmcts.sptribs.caseworker.event.page.IssueDecisionPreviewTemplate;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueDecisionSelectRecipients;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueDecisionSelectTemplate;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueDecisionUploadNotice;
-import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueDecision;
 import uk.gov.hmcts.sptribs.caseworker.util.MessageUtil;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
-import uk.gov.hmcts.sptribs.ciccase.model.LanguagePreference;
 import uk.gov.hmcts.sptribs.ciccase.model.State;
 import uk.gov.hmcts.sptribs.ciccase.model.UserRole;
 import uk.gov.hmcts.sptribs.common.ccd.CcdPageConfiguration;
 import uk.gov.hmcts.sptribs.common.ccd.PageBuilder;
-import uk.gov.hmcts.sptribs.document.CaseDataDocumentService;
-import uk.gov.hmcts.sptribs.document.content.DecisionTemplateContent;
 import uk.gov.hmcts.sptribs.document.model.CICDocument;
 import uk.gov.hmcts.sptribs.notification.dispatcher.DecisionIssuedNotification;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.Clock;
+import java.time.LocalDate;
 
 import static java.lang.String.format;
 import static uk.gov.hmcts.sptribs.caseworker.util.EventConstants.CASEWORKER_ISSUE_DECISION;
-import static uk.gov.hmcts.sptribs.caseworker.util.PageShowConditionsUtil.issueDecisionShowConditions;
 import static uk.gov.hmcts.sptribs.ciccase.model.State.AwaitingOutcome;
 import static uk.gov.hmcts.sptribs.ciccase.model.State.CaseManagement;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_CASEWORKER;
@@ -48,13 +41,11 @@ import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_SENIOR_JUDGE;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_WA_CONFIG_USER;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.sptribs.ciccase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.sptribs.document.DocumentConstants.DECISION_FILE;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
-public class CaseWorkerIssueDecision implements CCDConfig<CaseData, State, UserRole> {
-
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+public class CaseworkerIssueDecision implements CCDConfig<CaseData, State, UserRole> {
 
     private static final CcdPageConfiguration issueDecisionNotice = new IssueDecisionNotice();
     private static final CcdPageConfiguration issueDecisionSelectTemplate = new IssueDecisionSelectTemplate();
@@ -62,17 +53,10 @@ public class CaseWorkerIssueDecision implements CCDConfig<CaseData, State, UserR
     private static final CcdPageConfiguration issueDecisionUploadNotice = new IssueDecisionUploadNotice();
     private static final CcdPageConfiguration issueDecisionSelectRecipients = new IssueDecisionSelectRecipients();
     private static final CcdPageConfiguration issueDecisionMainContent = new IssueDecisionMainContent();
-    @Autowired
-    private CaseDataDocumentService caseDataDocumentService;
 
-    @Autowired
-    private DecisionTemplateContent decisionTemplateContent;
-
-    @Autowired
-    private DecisionIssuedNotification decisionIssuedNotification;
-
-    @Autowired
-    private HttpServletRequest request;
+    private final CcdPageConfiguration issueDecisionFooter;
+    private final DecisionIssuedNotification decisionIssuedNotification;
+    private final Clock clock;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -96,7 +80,7 @@ public class CaseWorkerIssueDecision implements CCDConfig<CaseData, State, UserR
         issueDecisionSelectTemplate.addTo(pageBuilder);
         issueDecisionMainContent.addTo(pageBuilder);
         issueDecisionUploadNotice.addTo(pageBuilder);
-        issueDecisionAddDocumentFooter(pageBuilder);
+        issueDecisionFooter.addTo(pageBuilder);
         issueDecisionPreviewTemplate.addTo(pageBuilder);
         issueDecisionSelectRecipients.addTo(pageBuilder);
 
@@ -112,35 +96,6 @@ public class CaseWorkerIssueDecision implements CCDConfig<CaseData, State, UserR
             .build();
     }
 
-    public AboutToStartOrSubmitResponse<CaseData, State> midEvent(
-        CaseDetails<CaseData, State> details,
-        CaseDetails<CaseData, State> detailsBefore
-    ) {
-
-        CaseData caseData = details.getData();
-        final CaseIssueDecision decision = caseData.getCaseIssueDecision();
-
-        final Long caseId = details.getId();
-
-        final String filename = DECISION_FILE + LocalDateTime.now().format(FORMATTER);
-
-        Document generalOrderDocument = caseDataDocumentService.renderDocument(
-            decisionTemplateContent.apply(caseData, caseId),
-            caseId,
-            decision.getIssueDecisionTemplate().getId(),
-            LanguagePreference.ENGLISH,
-            filename,
-            request
-        );
-
-        decision.setIssueDecisionDraft(generalOrderDocument);
-        caseData.setCaseIssueDecision(decision);
-
-        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
-            .data(caseData)
-            .build();
-    }
-
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> details,
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         final CaseData caseData = details.getData();
@@ -149,6 +104,8 @@ public class CaseWorkerIssueDecision implements CCDConfig<CaseData, State, UserR
         if (decisionDocument != null && decisionDocument.getDocumentLink() != null) {
             decisionDocument.getDocumentLink().setCategoryId("TD");
         }
+
+        caseData.getCaseIssueDecision().setDecisionDate(LocalDate.now());
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(caseData)
@@ -171,21 +128,6 @@ public class CaseWorkerIssueDecision implements CCDConfig<CaseData, State, UserR
             .confirmationHeader(format("# Decision notice issued %n## %s",
                 MessageUtil.generateSimpleMessage(details.getData().getCicCase())))
             .build();
-    }
-
-    private void issueDecisionAddDocumentFooter(PageBuilder pageBuilder) {
-        pageBuilder.page("issueDecisionAddDocumentFooter", this::midEvent)
-            .pageLabel("Document footer")
-            .label("LabelDocFooter",
-                """
-                    Decision Notice Signature
-
-                    Confirm the Role and Surname of the person who made this decision - this will be added
-                     to the bottom of the generated decision notice. E.g. 'Tribunal Judge Farrelly'
-                    """)
-            .pageShowConditions(issueDecisionShowConditions())
-            .mandatory(CaseData::getDecisionSignature)
-            .done();
     }
 
     private void sendIssueDecisionNotification(String caseNumber, CaseData data) {

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueDecision.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueDecision.java
@@ -105,7 +105,7 @@ public class CaseworkerIssueDecision implements CCDConfig<CaseData, State, UserR
             decisionDocument.getDocumentLink().setCategoryId("TD");
         }
 
-        caseData.getCaseIssueDecision().setDecisionDate(LocalDate.now());
+        caseData.getCaseIssueDecision().setDecisionDate(LocalDate.now(this.clock));
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(caseData)

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecision.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecision.java
@@ -128,7 +128,7 @@ public class CaseworkerIssueFinalDecision implements CCDConfig<CaseData, State, 
             finalDecisionDocument.getDocumentLink().setCategoryId("TD");
         }
 
-        caseData.getCaseIssueFinalDecision().setFinalDecisionDate(LocalDate.now());
+        caseData.getCaseIssueFinalDecision().setFinalDecisionDate(LocalDate.now(this.clock));
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(caseData)

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecision.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecision.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.sptribs.caseworker.event;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
@@ -17,7 +17,7 @@ import uk.gov.hmcts.sptribs.caseworker.event.page.IssueFinalDecisionNotice;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueFinalDecisionPreviewTemplate;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueFinalDecisionSelectRecipients;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueFinalDecisionSelectTemplate;
-import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueFinalDecision;
+import uk.gov.hmcts.sptribs.caseworker.event.page.IssueFinalDecisionUpload;
 import uk.gov.hmcts.sptribs.caseworker.util.MessageUtil;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
 import uk.gov.hmcts.sptribs.ciccase.model.CicCase;
@@ -27,19 +27,18 @@ import uk.gov.hmcts.sptribs.ciccase.model.UserRole;
 import uk.gov.hmcts.sptribs.common.ccd.CcdPageConfiguration;
 import uk.gov.hmcts.sptribs.common.ccd.PageBuilder;
 import uk.gov.hmcts.sptribs.document.CaseDataDocumentService;
-import uk.gov.hmcts.sptribs.document.content.FinalDecisionTemplateContent;
 import uk.gov.hmcts.sptribs.document.model.CICDocument;
 import uk.gov.hmcts.sptribs.notification.dispatcher.CaseFinalDecisionIssuedNotification;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
 import static uk.gov.hmcts.sptribs.caseworker.util.EventConstants.CASEWORKER_ISSUE_FINAL_DECISION;
-import static uk.gov.hmcts.sptribs.caseworker.util.PageShowConditionsUtil.issueFinalDecisionShowConditions;
 import static uk.gov.hmcts.sptribs.ciccase.model.State.AwaitingOutcome;
 import static uk.gov.hmcts.sptribs.ciccase.model.State.CaseClosed;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_CASEWORKER;
@@ -53,10 +52,9 @@ import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.sptribs.ciccase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.sptribs.document.DocumentConstants.FINAL_DECISION_ANNEX_FILE;
 import static uk.gov.hmcts.sptribs.document.DocumentConstants.FINAL_DECISION_ANNEX_TEMPLATE_ID;
-import static uk.gov.hmcts.sptribs.document.DocumentConstants.FINAL_DECISION_FILE;
-import static uk.gov.hmcts.sptribs.document.DocumentUtil.validateDecisionDocumentFormat;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class CaseworkerIssueFinalDecision implements CCDConfig<CaseData, State, UserRole> {
 
@@ -72,17 +70,17 @@ public class CaseworkerIssueFinalDecision implements CCDConfig<CaseData, State, 
 
     private static final CcdPageConfiguration issueFinalDecisionMainContent = new IssueFinalDecisionMainContent();
 
-    @Autowired
-    private HttpServletRequest request;
+    private static final CcdPageConfiguration issueFinalDecisionUpload = new IssueFinalDecisionUpload();
 
-    @Autowired
-    private CaseDataDocumentService caseDataDocumentService;
+    private final CcdPageConfiguration issueFinalDecisionFooter;
 
-    @Autowired
-    private FinalDecisionTemplateContent finalDecisionTemplateContent;
+    private final HttpServletRequest request;
 
-    @Autowired
-    private CaseFinalDecisionIssuedNotification caseFinalDecisionIssuedNotification;
+    private final CaseDataDocumentService caseDataDocumentService;
+
+    private final CaseFinalDecisionIssuedNotification caseFinalDecisionIssuedNotification;
+
+    private final Clock clock;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -105,8 +103,8 @@ public class CaseworkerIssueFinalDecision implements CCDConfig<CaseData, State, 
         issueFinalDecisionNotice.addTo(pageBuilder);
         issueFinalDecisionSelectTemplate.addTo(pageBuilder);
         issueFinalDecisionMainContent.addTo(pageBuilder);
-        uploadDocuments(pageBuilder);
-        issueFinalDecisionAddDocumentFooter(pageBuilder);
+        issueFinalDecisionUpload.addTo(pageBuilder);
+        issueFinalDecisionFooter.addTo(pageBuilder);
         issueFinalDecisionPreviewTemplate.addTo(pageBuilder);
         issueFinalDecisionSelectRecipients.addTo(pageBuilder);
     }
@@ -121,80 +119,6 @@ public class CaseworkerIssueFinalDecision implements CCDConfig<CaseData, State, 
             .build();
     }
 
-    private void uploadDocuments(PageBuilder pageBuilder) {
-
-        pageBuilder.page("issueFinalDecisionUpload", this::uploadDocumentMidEvent)
-            .pageLabel("Upload decision notice")
-            .pageShowConditions(issueFinalDecisionShowConditions())
-            .label("LabelDoc", """
-                Upload a copy of the decision notice that you want to add to this case.
-                  *  <h3>The decision notice should be:</h3>
-                  *  a maximum of 100MB in size (larger files must be split)
-                  *  labelled clearly, e.g. applicant-name-decision-notice.pdf
-
-
-
-
-                  Note: If the remove button is disabled, please refresh the page to remove attachments
-                """
-            )
-            .complex(CaseData::getCaseIssueFinalDecision)
-            .mandatoryWithLabel(CaseIssueFinalDecision::getDocument, "File Attachments")
-            .done();
-    }
-
-    private void issueFinalDecisionAddDocumentFooter(PageBuilder pageBuilder) {
-        pageBuilder.page("issueFinalDecisionAddDocumentFooter", this::midEvent)
-            .pageLabel("Document footer")
-            .label("LabelIssueFinalDecisionAddDocumentFooter",
-                """
-                    Decision Notice Signature
-
-                    Confirm the Role and Surname of the person who made this decision - this will be added
-                     to the bottom of the generated decision notice. E.g. 'Tribunal Judge Farrelly'
-                    """)
-            .pageShowConditions(issueFinalDecisionShowConditions())
-            .mandatory(CaseData::getDecisionSignature)
-            .done();
-    }
-
-    public AboutToStartOrSubmitResponse<CaseData, State> midEvent(CaseDetails<CaseData, State> details,
-                                                                  CaseDetails<CaseData, State> detailsBefore) {
-
-        final CaseData caseData = details.getData();
-        final CaseIssueFinalDecision finalDecision = caseData.getCaseIssueFinalDecision();
-        final Long caseId = details.getId();
-        final String filename = FINAL_DECISION_FILE + LocalDateTime.now().format(formatter);
-
-        Document generalOrderDocument = caseDataDocumentService.renderDocument(
-            finalDecisionTemplateContent.apply(caseData, caseId),
-            caseId,
-            finalDecision.getDecisionTemplate().getId(),
-            LanguagePreference.ENGLISH,
-            filename,
-            request
-        );
-
-        finalDecision.setFinalDecisionDraft(generalOrderDocument);
-        caseData.setCaseIssueFinalDecision(finalDecision);
-
-        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
-            .data(caseData)
-            .build();
-    }
-
-    public AboutToStartOrSubmitResponse<CaseData, State> uploadDocumentMidEvent(CaseDetails<CaseData, State> details,
-                                                                                 CaseDetails<CaseData, State> detailsBefore) {
-        final CaseData data = details.getData();
-        CICDocument uploadedDocument = data.getCaseIssueFinalDecision().getDocument();
-        final List<String> errors = validateDecisionDocumentFormat(uploadedDocument);
-
-        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
-            .data(data)
-            .errors(errors)
-            .build();
-    }
-
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> details,
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         final CaseData caseData = details.getData();
@@ -203,6 +127,8 @@ public class CaseworkerIssueFinalDecision implements CCDConfig<CaseData, State, 
         if (finalDecisionDocument != null) {
             finalDecisionDocument.getDocumentLink().setCategoryId("TD");
         }
+
+        caseData.getCaseIssueFinalDecision().setFinalDecisionDate(LocalDate.now());
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(caseData)

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueDecisionFooter.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueDecisionFooter.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.sptribs.caseworker.event.page;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.Document;
+import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueDecision;
+import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
+import uk.gov.hmcts.sptribs.ciccase.model.LanguagePreference;
+import uk.gov.hmcts.sptribs.ciccase.model.State;
+import uk.gov.hmcts.sptribs.common.ccd.CcdPageConfiguration;
+import uk.gov.hmcts.sptribs.common.ccd.PageBuilder;
+import uk.gov.hmcts.sptribs.document.CaseDataDocumentService;
+import uk.gov.hmcts.sptribs.document.content.DecisionTemplateContent;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static uk.gov.hmcts.sptribs.caseworker.util.PageShowConditionsUtil.issueDecisionShowConditions;
+import static uk.gov.hmcts.sptribs.document.DocumentConstants.DECISION_FILE;
+
+@Component
+@RequiredArgsConstructor
+public class IssueDecisionFooter implements CcdPageConfiguration {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private final CaseDataDocumentService caseDataDocumentService;
+    private final DecisionTemplateContent decisionTemplateContent;
+    private final HttpServletRequest request;
+
+    @Override
+    public void addTo(PageBuilder pageBuilder) {
+        pageBuilder.page("issueDecisionAddDocumentFooter", this::midEvent)
+            .pageLabel("Document footer")
+            .label("LabelDocFooter",
+                """
+                    Decision Notice Signature
+ 
+                    Confirm the Role and Surname of the person who made this decision - this will be added
+                     to the bottom of the generated decision notice. E.g. 'Tribunal Judge Farrelly'
+                    """)
+            .pageShowConditions(issueDecisionShowConditions())
+            .mandatory(CaseData::getDecisionSignature)
+            .done();
+    }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> midEvent(CaseDetails<CaseData, State> details,
+                                                                  CaseDetails<CaseData, State> detailsBefore) {
+        final CaseData caseData = details.getData();
+        final CaseIssueDecision decision = caseData.getCaseIssueDecision();
+
+        final Long caseId = details.getId();
+
+        final String filename = DECISION_FILE + LocalDateTime.now().format(FORMATTER);
+
+        Document generalOrderDocument = caseDataDocumentService.renderDocument(
+            decisionTemplateContent.apply(caseData, caseId),
+            caseId,
+            decision.getIssueDecisionTemplate().getId(),
+            LanguagePreference.ENGLISH,
+            filename,
+            request
+        );
+
+        decision.setIssueDecisionDraft(generalOrderDocument);
+        caseData.setCaseIssueDecision(decision);
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(caseData)
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionFooter.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionFooter.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.sptribs.caseworker.event.page;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.Document;
+import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueFinalDecision;
+import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
+import uk.gov.hmcts.sptribs.ciccase.model.LanguagePreference;
+import uk.gov.hmcts.sptribs.ciccase.model.State;
+import uk.gov.hmcts.sptribs.common.ccd.CcdPageConfiguration;
+import uk.gov.hmcts.sptribs.common.ccd.PageBuilder;
+import uk.gov.hmcts.sptribs.document.CaseDataDocumentService;
+import uk.gov.hmcts.sptribs.document.content.FinalDecisionTemplateContent;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static uk.gov.hmcts.sptribs.caseworker.util.PageShowConditionsUtil.issueFinalDecisionShowConditions;
+import static uk.gov.hmcts.sptribs.document.DocumentConstants.FINAL_DECISION_FILE;
+
+@Component
+@RequiredArgsConstructor
+public class IssueFinalDecisionFooter implements CcdPageConfiguration {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private final CaseDataDocumentService caseDataDocumentService;
+    private final FinalDecisionTemplateContent finalDecisionTemplateContent;
+    private final HttpServletRequest request;
+
+    @Override
+    public void addTo(PageBuilder pageBuilder) {
+        pageBuilder.page("issueFinalDecisionAddDocumentFooter", this::midEvent)
+            .pageLabel("Document footer")
+            .label("LabelIssueFinalDecisionAddDocumentFooter",
+                """
+                    Decision Notice Signature
+
+                    Confirm the Role and Surname of the person who made this decision - this will be added
+                     to the bottom of the generated decision notice. E.g. 'Tribunal Judge Farrelly'
+                    """)
+            .pageShowConditions(issueFinalDecisionShowConditions())
+            .mandatory(CaseData::getDecisionSignature)
+            .done();
+    }
+
+
+    public AboutToStartOrSubmitResponse<CaseData, State> midEvent(CaseDetails<CaseData, State> details,
+                                                                  CaseDetails<CaseData, State> detailsBefore) {
+        final CaseData caseData = details.getData();
+        final CaseIssueFinalDecision finalDecision = caseData.getCaseIssueFinalDecision();
+        final Long caseId = details.getId();
+        final String filename = FINAL_DECISION_FILE + LocalDateTime.now().format(formatter);
+
+        Document generalOrderDocument = caseDataDocumentService.renderDocument(
+            finalDecisionTemplateContent.apply(caseData, caseId),
+            caseId,
+            finalDecision.getDecisionTemplate().getId(),
+            LanguagePreference.ENGLISH,
+            filename,
+            request
+        );
+
+        finalDecision.setFinalDecisionDraft(generalOrderDocument);
+        caseData.setCaseIssueFinalDecision(finalDecision);
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(caseData)
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionUpload.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionUpload.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.sptribs.caseworker.event.page;
+
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueFinalDecision;
+import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
+import uk.gov.hmcts.sptribs.ciccase.model.State;
+import uk.gov.hmcts.sptribs.common.ccd.CcdPageConfiguration;
+import uk.gov.hmcts.sptribs.common.ccd.PageBuilder;
+import uk.gov.hmcts.sptribs.document.model.CICDocument;
+
+import java.util.List;
+
+import static uk.gov.hmcts.sptribs.caseworker.util.PageShowConditionsUtil.issueFinalDecisionShowConditions;
+import static uk.gov.hmcts.sptribs.document.DocumentUtil.validateDecisionDocumentFormat;
+
+public class IssueFinalDecisionUpload implements CcdPageConfiguration {
+
+    @Override
+    public void addTo(PageBuilder pageBuilder) {
+        pageBuilder.page("issueFinalDecisionUpload", this::midEvent)
+            .pageLabel("Upload decision notice")
+            .pageShowConditions(issueFinalDecisionShowConditions())
+            .label("LabelDoc", """
+            Upload a copy of the decision notice that you want to add to this case.
+              *  <h3>The decision notice should be:</h3>
+              *  a maximum of 100MB in size (larger files must be split)
+              *  labelled clearly, e.g. applicant-name-decision-notice.pdf
+
+
+
+
+              Note: If the remove button is disabled, please refresh the page to remove attachments
+            """
+            )
+            .complex(CaseData::getCaseIssueFinalDecision)
+            .mandatoryWithLabel(CaseIssueFinalDecision::getDocument, "File Attachments")
+            .done();
+    }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> midEvent(CaseDetails<CaseData, State> details,
+                                                                  CaseDetails<CaseData, State> detailsBefore) {
+        final CaseData data = details.getData();
+        CICDocument uploadedDocument = data.getCaseIssueFinalDecision().getDocument();
+        final List<String> errors = validateDecisionDocumentFormat(uploadedDocument);
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(data)
+            .errors(errors)
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/model/CaseIssueDecision.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/model/CaseIssueDecision.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.sptribs.caseworker.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,8 @@ import uk.gov.hmcts.sptribs.ciccase.model.DecisionTemplate;
 import uk.gov.hmcts.sptribs.ciccase.model.access.CaseworkerWithCAAAccess;
 import uk.gov.hmcts.sptribs.ciccase.model.access.DefaultAccess;
 import uk.gov.hmcts.sptribs.document.model.CICDocument;
+
+import java.time.LocalDate;
 
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
 
@@ -48,4 +51,11 @@ public class CaseIssueDecision {
         access = {DefaultAccess.class}
     )
     private CICDocument decisionDocument;
+
+    @CCD(
+        label = "Decision Date",
+        access = {DefaultAccess.class, CaseworkerWithCAAAccess.class}
+    )
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate decisionDate;
 }

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/model/CaseIssueFinalDecision.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/model/CaseIssueFinalDecision.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.sptribs.caseworker.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,8 @@ import uk.gov.hmcts.sptribs.ciccase.model.DecisionTemplate;
 import uk.gov.hmcts.sptribs.ciccase.model.access.CaseworkerWithCAAAccess;
 import uk.gov.hmcts.sptribs.ciccase.model.access.DefaultAccess;
 import uk.gov.hmcts.sptribs.document.model.CICDocument;
+
+import java.time.LocalDate;
 
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
 
@@ -54,4 +57,11 @@ public class CaseIssueFinalDecision {
         access = {DefaultAccess.class}
     )
     private CICDocument document;
+
+    @CCD(
+        label = "Final Decision Date",
+        access = {DefaultAccess.class, CaseworkerWithCAAAccess.class}
+    )
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate finalDecisionDate;
 }

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/util/DecisionDocumentListUtil.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/util/DecisionDocumentListUtil.java
@@ -27,6 +27,7 @@ public  final class DecisionDocumentListUtil {
                     .documentEmailContent(caseData.getCaseIssueDecision().getDecisionDocument().getDocumentEmailContent())
                     .documentLink(caseData.getCaseIssueDecision().getDecisionDocument().getDocumentLink())
                     .documentCategory(DocumentType.TRIBUNAL_DIRECTION)
+                    .date(caseData.getCaseIssueDecision().getDecisionDate())
                     .build();
                 decisionDocs.add(doc);
             }
@@ -36,6 +37,7 @@ public  final class DecisionDocumentListUtil {
                 CaseworkerCICDocument doc = CaseworkerCICDocument.builder()
                     .documentLink(caseData.getCaseIssueDecision().getIssueDecisionDraft())
                     .documentCategory(DocumentType.TRIBUNAL_DIRECTION)
+                    .date(caseData.getCaseIssueDecision().getDecisionDate())
                     .build();
                 decisionDocs.add(doc);
             }
@@ -52,6 +54,7 @@ public  final class DecisionDocumentListUtil {
                     .documentEmailContent(caseData.getCaseIssueFinalDecision().getDocument().getDocumentEmailContent())
                     .documentLink(caseData.getCaseIssueFinalDecision().getDocument().getDocumentLink())
                     .documentCategory(DocumentType.TRIBUNAL_DIRECTION)
+                    .date(caseData.getCaseIssueFinalDecision().getFinalDecisionDate())
                     .build();
                 finalDecisionDocs.add(doc);
             }
@@ -61,6 +64,7 @@ public  final class DecisionDocumentListUtil {
                 CaseworkerCICDocument doc = CaseworkerCICDocument.builder()
                     .documentLink(caseData.getCaseIssueFinalDecision().getFinalDecisionDraft())
                     .documentCategory(DocumentType.TRIBUNAL_DIRECTION)
+                    .date(caseData.getCaseIssueFinalDecision().getFinalDecisionDate())
                     .build();
                 finalDecisionDocs.add(doc);
             }

--- a/src/main/java/uk/gov/hmcts/sptribs/caseworker/util/OrderDocumentListUtil.java
+++ b/src/main/java/uk/gov/hmcts/sptribs/caseworker/util/OrderDocumentListUtil.java
@@ -35,6 +35,7 @@ public final class OrderDocumentListUtil {
                     CaseworkerCICDocument doc = CaseworkerCICDocument.builder()
                         .documentLink(templateGeneratedDoc)
                         .documentCategory(DocumentType.TRIBUNAL_DIRECTION)
+                        .date(orderListValue.getValue().getOrderSentDate())
                         .build();
                     orderList.add(doc);
                 } else if (!CollectionUtils.isEmpty(orderListValue.getValue().getUploadedFile())) {
@@ -54,6 +55,7 @@ public final class OrderDocumentListUtil {
                     .documentLink(document.getValue().getDocumentLink())
                     .documentEmailContent(document.getValue().getDocumentEmailContent())
                     .documentCategory(DocumentType.TRIBUNAL_DIRECTION)
+                    .date(orderListValue.getValue().getOrderSentDate())
                     .build();
                 orderUploadList.add(doc);
             }

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerCreateBundleTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerCreateBundleTest.java
@@ -10,8 +10,11 @@ import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.sptribs.caseworker.model.DocumentManagement;
+import uk.gov.hmcts.sptribs.caseworker.model.DraftOrderCIC;
+import uk.gov.hmcts.sptribs.caseworker.model.Order;
 import uk.gov.hmcts.sptribs.caseworker.model.YesNo;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
 import uk.gov.hmcts.sptribs.ciccase.model.CicCase;
@@ -225,6 +228,11 @@ class CaseworkerCreateBundleTest {
 
         cicCase.setApplicantDocumentsUploaded(allApplicantDocs);
 
+        Document document = Document.builder().url("testUrl").filename("test").build();
+        DraftOrderCIC draftOrderCIC = DraftOrderCIC.builder().templateGeneratedDocument(document).build();
+        Order order = Order.builder().draftOrder(draftOrderCIC).orderSentDate(LocalDate.of(2026, 5, 1)).build();
+        cicCase.setOrderList(List.of(ListValue.<Order>builder().value(order).build()));
+
         LocalDate caseworkerUploadDate = LocalDate.of(2026, 1, 20);
         final List<ListValue<CaseworkerCICDocument>> caseworkerDocs =
             getCaseworkerCICDocumentList("caseworkerDoc.docx", DocumentType.LINKED_DOCS, caseworkerUploadDate);
@@ -253,7 +261,7 @@ class CaseworkerCreateBundleTest {
             // Initial documents should be in caseDocuments
             assertThat(dataAtMockTime.getCaseDocuments()).hasSize(3);
             // furtherCaseDocuments should have the additional documents
-            assertThat(dataAtMockTime.getFurtherCaseDocuments()).hasSize(5);
+            assertThat(dataAtMockTime.getFurtherCaseDocuments()).hasSize(6);
             assertThat(dataAtMockTime.getBundleConfiguration()).isEqualTo(MULTI_BUNDLE_CONFIG);
             assertThat(dataAtMockTime.getMultiBundleConfiguration()).isEqualTo(List.of(MULTI_BUNDLE_CONFIG));
             return List.of(bundle);

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueDecisionTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.sptribs.caseworker.event;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,13 +13,13 @@ import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
+import uk.gov.hmcts.sptribs.caseworker.event.page.IssueDecisionFooter;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueDecisionSelectTemplate;
 import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueDecision;
 import uk.gov.hmcts.sptribs.ciccase.model.ApplicantCIC;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
 import uk.gov.hmcts.sptribs.ciccase.model.CicCase;
 import uk.gov.hmcts.sptribs.ciccase.model.DecisionTemplate;
-import uk.gov.hmcts.sptribs.ciccase.model.LanguagePreference;
 import uk.gov.hmcts.sptribs.ciccase.model.RepresentativeCIC;
 import uk.gov.hmcts.sptribs.ciccase.model.RespondentCIC;
 import uk.gov.hmcts.sptribs.ciccase.model.State;
@@ -31,13 +32,12 @@ import uk.gov.hmcts.sptribs.document.content.DocmosisTemplateConstants;
 import uk.gov.hmcts.sptribs.document.model.CICDocument;
 import uk.gov.hmcts.sptribs.notification.dispatcher.DecisionIssuedNotification;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.sptribs.ciccase.model.State.CaseManagement;
 import static uk.gov.hmcts.sptribs.ciccase.model.UserRole.ST_CIC_WA_CONFIG_USER;
 import static uk.gov.hmcts.sptribs.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
@@ -55,13 +55,31 @@ class CaseworkerIssueDecisionTest {
     private DecisionTemplateContent decisionTemplateContent;
 
     @InjectMocks
-    private CaseWorkerIssueDecision issueDecision;
-
-    @InjectMocks
     private IssueDecisionSelectTemplate issueDecisionSelectTemplate;
 
     @Mock
     private DecisionIssuedNotification decisionIssuedNotification;
+
+    @Mock
+    private IssueDecisionFooter issueDecisionFooter;
+
+    private final Clock fixedClock = Clock.fixed(
+        LocalDate.of(2026, 5, 15)
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant(),
+        ZoneId.systemDefault()
+    );
+
+    private CaseworkerIssueDecision issueDecision;
+
+    @BeforeEach
+    void setUp() {
+        issueDecision = new CaseworkerIssueDecision(
+            issueDecisionFooter,
+            decisionIssuedNotification,
+            fixedClock
+        );
+    }
 
     @Test
     void shouldAddPublishToCamundaWhenWAIsEnabled() {
@@ -75,18 +93,18 @@ class CaseworkerIssueDecisionTest {
             .contains(CASEWORKER_ISSUE_DECISION);
 
         assertThat(getEventsFrom(configBuilder).values())
-                .extracting(Event::isPublishToCamunda)
-                .contains(true);
+            .extracting(Event::isPublishToCamunda)
+            .contains(true);
 
         assertThat(getEventsFrom(configBuilder).values())
-                .extracting(Event::getGrants)
-                .extracting(map -> map.containsKey(ST_CIC_WA_CONFIG_USER))
-                .contains(true);
+            .extracting(Event::getGrants)
+            .extracting(map -> map.containsKey(ST_CIC_WA_CONFIG_USER))
+            .contains(true);
 
         assertThat(getEventsFrom(configBuilder).values())
-                .extracting(Event::getGrants)
-                .extracting(map -> map.get(ST_CIC_WA_CONFIG_USER))
-                .contains(Permissions.CREATE_READ_UPDATE);
+            .extracting(Event::getGrants)
+            .extracting(map -> map.get(ST_CIC_WA_CONFIG_USER))
+            .contains(Permissions.CREATE_READ_UPDATE);
     }
 
     @Test
@@ -109,6 +127,7 @@ class CaseworkerIssueDecisionTest {
 
         //Then
         assertThat(response.getState()).isEqualTo(CaseManagement);
+        assertThat(response.getData().getCaseIssueDecision().getDecisionDate()).isEqualTo(LocalDate.of(2026, 5, 15));
     }
 
     @Test
@@ -134,32 +153,6 @@ class CaseworkerIssueDecisionTest {
 
         //Then
         assertThat(response.getConfirmationHeader()).contains("Decision notice issued");
-    }
-
-    @Test
-    void shouldRenderDocumentWithoutError() {
-        //Given
-        final CaseIssueDecision caseIssueDecision = new CaseIssueDecision();
-        caseIssueDecision.setIssueDecisionTemplate(DecisionTemplate.ELIGIBILITY);
-        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
-        final CaseData caseData = CaseData.builder()
-            .caseIssueDecision(caseIssueDecision)
-            .build();
-        caseDetails.setData(caseData);
-        Document document = new Document();
-        when(caseDataDocumentService.renderDocument(
-            anyMap(),
-            any(),
-            eq(DecisionTemplate.ELIGIBILITY.getId()),
-            eq(LanguagePreference.ENGLISH), any(), any()))
-            .thenReturn(document);
-
-        //When
-        AboutToStartOrSubmitResponse<CaseData, State> response = issueDecision.midEvent(caseDetails, caseDetails);
-
-        //Then
-        assertThat(response.getErrors()).isNull();
-        assertThat(caseIssueDecision.getIssueDecisionDraft()).isEqualTo(document);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/CaseworkerIssueFinalDecisionTest.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.sptribs.caseworker.event;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,9 +14,10 @@ import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
+import uk.gov.hmcts.sptribs.caseworker.event.page.IssueFinalDecisionFooter;
 import uk.gov.hmcts.sptribs.caseworker.event.page.IssueFinalDecisionSelectTemplate;
+import uk.gov.hmcts.sptribs.caseworker.event.page.IssueFinalDecisionUpload;
 import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueFinalDecision;
-import uk.gov.hmcts.sptribs.caseworker.model.NoticeOption;
 import uk.gov.hmcts.sptribs.ciccase.model.ApplicantCIC;
 import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
 import uk.gov.hmcts.sptribs.ciccase.model.CicCase;
@@ -26,12 +29,14 @@ import uk.gov.hmcts.sptribs.ciccase.model.SubjectCIC;
 import uk.gov.hmcts.sptribs.ciccase.model.UserRole;
 import uk.gov.hmcts.sptribs.ciccase.model.access.Permissions;
 import uk.gov.hmcts.sptribs.document.CaseDataDocumentService;
-import uk.gov.hmcts.sptribs.document.DocumentConstants;
 import uk.gov.hmcts.sptribs.document.content.DocmosisTemplateConstants;
 import uk.gov.hmcts.sptribs.document.content.FinalDecisionTemplateContent;
 import uk.gov.hmcts.sptribs.document.model.CICDocument;
 import uk.gov.hmcts.sptribs.notification.dispatcher.CaseFinalDecisionIssuedNotification;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,14 +56,40 @@ class CaseworkerIssueFinalDecisionTest {
     @Mock
     private FinalDecisionTemplateContent finalDecisionTemplateContent;
 
-    @InjectMocks
-    private CaseworkerIssueFinalDecision issueFinalDecision;
-
     @Mock
     private CaseFinalDecisionIssuedNotification caseFinalDecisionIssuedNotification;
 
     @InjectMocks
     private IssueFinalDecisionSelectTemplate issueFinalDecisionSelectTemplate;
+
+    @Mock
+    private IssueFinalDecisionFooter issueFinalDecisionFooter;
+
+    @Mock
+    private IssueFinalDecisionUpload issueFinalDecisionUpload;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    private final Clock fixedClock = Clock.fixed(
+        LocalDate.of(2026, 5, 15)
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant(),
+        ZoneId.systemDefault()
+    );
+
+    private CaseworkerIssueFinalDecision issueFinalDecision;
+
+    @BeforeEach
+    void setUp() {
+        issueFinalDecision = new CaseworkerIssueFinalDecision(
+            issueFinalDecisionFooter,
+            httpServletRequest,
+            caseDataDocumentService,
+            caseFinalDecisionIssuedNotification,
+            fixedClock
+        );
+    }
 
     @Test
     void shouldAddPublishToCamundaWhenWAIsEnabled() {
@@ -72,32 +103,18 @@ class CaseworkerIssueFinalDecisionTest {
             .contains(CASEWORKER_ISSUE_FINAL_DECISION);
 
         assertThat(getEventsFrom(configBuilder).values())
-                .extracting(Event::isPublishToCamunda)
-                .contains(true);
+            .extracting(Event::isPublishToCamunda)
+            .contains(true);
 
         assertThat(getEventsFrom(configBuilder).values())
-                .extracting(Event::getGrants)
-                .extracting(map -> map.containsKey(ST_CIC_WA_CONFIG_USER))
-                .contains(true);
+            .extracting(Event::getGrants)
+            .extracting(map -> map.containsKey(ST_CIC_WA_CONFIG_USER))
+            .contains(true);
 
         assertThat(getEventsFrom(configBuilder).values())
-                .extracting(Event::getGrants)
-                .extracting(map -> map.get(ST_CIC_WA_CONFIG_USER))
-                .contains(Permissions.CREATE_READ_UPDATE);
-    }
-
-    @Test
-    void shouldSuccessfullyIssueFinalDecision() {
-        //Given
-        final CaseData caseData = caseData();
-        final CaseIssueFinalDecision finalDecision = new CaseIssueFinalDecision();
-        finalDecision.setFinalDecisionNotice(NoticeOption.CREATE_FROM_TEMPLATE);
-        finalDecision.setDecisionTemplate(DecisionTemplate.QUANTUM);
-        caseData.setCaseIssueFinalDecision(finalDecision);
-
-        //Then
-        assertThat(caseData.getCaseIssueFinalDecision().getDecisionTemplate().getId()).isEqualTo("ST-CIC-DEC-ENG-CIC2_Quantum");
-        assertThat(caseData.getCaseIssueFinalDecision().getDecisionTemplate().getLabel()).contains("Quantum");
+            .extracting(Event::getGrants)
+            .extracting(map -> map.get(ST_CIC_WA_CONFIG_USER))
+            .contains(Permissions.CREATE_READ_UPDATE);
     }
 
     @Test
@@ -144,48 +161,8 @@ class CaseworkerIssueFinalDecisionTest {
         //Then
         assertThat(response.getState())
             .isEqualTo(CaseClosed);
+        assertThat(response.getData().getCaseIssueFinalDecision().getFinalDecisionDate()).isEqualTo(LocalDate.of(2026, 5,15));
     }
-
-    @Test
-    void shouldReturnErrorsInvalidDocumentUploaded() {
-        //Given
-
-        final CICDocument document = CICDocument.builder()
-            .documentLink(Document.builder().binaryUrl("url").url("url").filename("file.sql").build())
-            .documentEmailContent("content")
-            .build();
-        final CaseIssueFinalDecision caseIssueFinalDecision = CaseIssueFinalDecision.builder().document(document).build();
-        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
-        final CaseData caseData = CaseData.builder()
-            .caseIssueFinalDecision(caseIssueFinalDecision)
-            .build();
-        caseDetails.setData(caseData);
-
-        //When
-        AboutToStartOrSubmitResponse<CaseData, State> response = issueFinalDecision.uploadDocumentMidEvent(caseDetails, caseDetails);
-
-        //Then
-        assertThat(response.getErrors()).contains(DocumentConstants.DOCUMENT_VALIDATION_MESSAGE);
-    }
-
-    @Test
-    void shouldReturnErrorsIfNoNotificationPartySelected() {
-        //Given
-        final CaseIssueFinalDecision caseIssueFinalDecision = new CaseIssueFinalDecision();
-        caseIssueFinalDecision.setDecisionTemplate(DecisionTemplate.ELIGIBILITY);
-        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
-        final CaseData caseData = CaseData.builder()
-            .caseIssueFinalDecision(caseIssueFinalDecision)
-            .build();
-        caseDetails.setData(caseData);
-
-        //When
-        AboutToStartOrSubmitResponse<CaseData, State> response = issueFinalDecision.midEvent(caseDetails, caseDetails);
-
-        //Then
-        assertThat(response.getErrors()).isNull();
-    }
-
 
     @Test
     void shouldReturnMainContentOnMidEvent() {
@@ -204,7 +181,6 @@ class CaseworkerIssueFinalDecisionTest {
         //Then
         Assertions.assertEquals(DocmosisTemplateConstants.ELIGIBILITY_MAIN_CONTENT, response.getData().getDecisionMainContent());
     }
-
 
     @Test
     void shouldRunAboutToStart() {

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueDecisionFooterTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueDecisionFooterTest.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.sptribs.caseworker.event.page;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.Document;
+import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueDecision;
+import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
+import uk.gov.hmcts.sptribs.ciccase.model.DecisionTemplate;
+import uk.gov.hmcts.sptribs.ciccase.model.LanguagePreference;
+import uk.gov.hmcts.sptribs.ciccase.model.State;
+import uk.gov.hmcts.sptribs.document.CaseDataDocumentService;
+import uk.gov.hmcts.sptribs.document.content.DecisionTemplateContent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IssueDecisionFooterTest {
+
+    @InjectMocks
+    private IssueDecisionFooter issueDecisionFooter;
+
+    @Mock
+    private CaseDataDocumentService caseDataDocumentService;
+
+    @Mock
+    private DecisionTemplateContent decisionTemplateContent;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @Test
+    void shouldRenderDocumentWithoutError() {
+        //Given
+        final CaseIssueDecision caseIssueDecision = new CaseIssueDecision();
+        caseIssueDecision.setIssueDecisionTemplate(DecisionTemplate.ELIGIBILITY);
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        final CaseData caseData = CaseData.builder()
+                .caseIssueDecision(caseIssueDecision)
+                .build();
+        caseDetails.setData(caseData);
+        Document document = new Document();
+        when(caseDataDocumentService.renderDocument(
+                anyMap(),
+                any(),
+                eq(DecisionTemplate.ELIGIBILITY.getId()),
+                eq(LanguagePreference.ENGLISH), any(), any()))
+                .thenReturn(document);
+
+        //When
+        AboutToStartOrSubmitResponse<CaseData, State> response = issueDecisionFooter.midEvent(caseDetails, caseDetails);
+
+        //Then
+        assertThat(response.getErrors()).isNull();
+        assertThat(caseIssueDecision.getIssueDecisionDraft()).isEqualTo(document);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionFooterTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionFooterTest.java
@@ -15,14 +15,10 @@ import uk.gov.hmcts.sptribs.ciccase.model.State;
 import uk.gov.hmcts.sptribs.document.CaseDataDocumentService;
 import uk.gov.hmcts.sptribs.document.content.FinalDecisionTemplateContent;
 
-import java.time.format.DateTimeFormatter;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class IssueFinalDecisionFooterTest {
-
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     @InjectMocks
     private IssueFinalDecisionFooter issueFinalDecisionFooter;

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionFooterTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionFooterTest.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.sptribs.caseworker.event.page;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.netty.http.server.HttpServerRequest;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueFinalDecision;
+import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
+import uk.gov.hmcts.sptribs.ciccase.model.DecisionTemplate;
+import uk.gov.hmcts.sptribs.ciccase.model.State;
+import uk.gov.hmcts.sptribs.document.CaseDataDocumentService;
+import uk.gov.hmcts.sptribs.document.content.FinalDecisionTemplateContent;
+
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class IssueFinalDecisionFooterTest {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @InjectMocks
+    private IssueFinalDecisionFooter issueFinalDecisionFooter;
+
+    @Mock
+    private CaseDataDocumentService caseDataDocumentService;
+
+    @Mock
+    private FinalDecisionTemplateContent finalDecisionTemplateContent;
+
+    @Mock
+    private HttpServerRequest httpServerRequest;
+
+    @Test
+    void shouldReturnErrorsIfNoNotificationPartySelected() {
+        //Given
+        final CaseIssueFinalDecision caseIssueFinalDecision = new CaseIssueFinalDecision();
+        caseIssueFinalDecision.setDecisionTemplate(DecisionTemplate.ELIGIBILITY);
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        final CaseData caseData = CaseData.builder()
+                .caseIssueFinalDecision(caseIssueFinalDecision)
+                .build();
+        caseDetails.setData(caseData);
+
+        //When
+        AboutToStartOrSubmitResponse<CaseData, State> response = issueFinalDecisionFooter.midEvent(caseDetails, caseDetails);
+
+        //Then
+        assertThat(response.getErrors()).isNull();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionUploadTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/event/page/IssueFinalDecisionUploadTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.sptribs.caseworker.event.page;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.Document;
+import uk.gov.hmcts.sptribs.caseworker.model.CaseIssueFinalDecision;
+import uk.gov.hmcts.sptribs.ciccase.model.CaseData;
+import uk.gov.hmcts.sptribs.ciccase.model.State;
+import uk.gov.hmcts.sptribs.document.DocumentConstants;
+import uk.gov.hmcts.sptribs.document.model.CICDocument;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class IssueFinalDecisionUploadTest {
+    @InjectMocks
+    private IssueFinalDecisionUpload issueFinalDecisionUpload;
+
+    @Test
+    void shouldReturnErrorsInvalidDocumentUploaded() {
+        //Given
+
+        final CICDocument document = CICDocument.builder()
+            .documentLink(Document.builder().binaryUrl("url").url("url").filename("file.sql").build())
+            .documentEmailContent("content")
+            .build();
+        final CaseIssueFinalDecision caseIssueFinalDecision = CaseIssueFinalDecision.builder().document(document).build();
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        final CaseData caseData = CaseData.builder()
+            .caseIssueFinalDecision(caseIssueFinalDecision)
+            .build();
+        caseDetails.setData(caseData);
+
+        //When
+        AboutToStartOrSubmitResponse<CaseData, State> response = issueFinalDecisionUpload.midEvent(caseDetails, caseDetails);
+
+        //Then
+        assertThat(response.getErrors()).contains(DocumentConstants.DOCUMENT_VALIDATION_MESSAGE);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/util/OrderDocumentListUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/util/OrderDocumentListUtilTest.java
@@ -43,8 +43,8 @@ public class OrderDocumentListUtilTest {
         List<CaseworkerCICDocument> result = OrderDocumentListUtil.getOrderDocuments(cicCase);
 
         //Then
-        assertThat(result).isNotNull();
-        assertThat(result).hasSize(1);
+        assertThat(result).isNotNull()
+            .hasSize(1);
 
         CaseworkerCICDocument orderDocument = result.getFirst();
         assertThat(orderDocument.getDocumentLink()).isEqualTo(document.getDocumentLink());
@@ -66,8 +66,8 @@ public class OrderDocumentListUtilTest {
         List<CaseworkerCICDocument> result = OrderDocumentListUtil.getOrderDocuments(cicCase);
 
         //Then
-        assertThat(result).isNotNull();
-        assertThat(result).hasSize(1);
+        assertThat(result).isNotNull()
+            .hasSize(1);
 
         CaseworkerCICDocument orderDocument = result.getFirst();
         assertThat(orderDocument.getDocumentLink()).isEqualTo(document);

--- a/src/test/java/uk/gov/hmcts/sptribs/caseworker/util/OrderDocumentListUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/sptribs/caseworker/util/OrderDocumentListUtilTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.sptribs.ciccase.model.CicCase;
 import uk.gov.hmcts.sptribs.document.model.CICDocument;
 import uk.gov.hmcts.sptribs.document.model.CaseworkerCICDocument;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,11 +30,11 @@ public class OrderDocumentListUtilTest {
     @Test
     void shouldGenerateOrderDocUpload() {
         //Given
-
         CICDocument document = CICDocument.builder().documentLink(Document.builder().filename("name").build()).build();
         ListValue<CICDocument> cicDocumentListValue = new ListValue<>();
         cicDocumentListValue.setValue(document);
-        Order order = Order.builder().uploadedFile(List.of(cicDocumentListValue)).build();
+        LocalDate orderSentDate = LocalDate.of(2026, 4, 20);
+        Order order = Order.builder().uploadedFile(List.of(cicDocumentListValue)).orderSentDate(orderSentDate).build();
         ListValue<Order> orderListValue = new ListValue<>();
         orderListValue.setValue(order);
         CicCase cicCase = CicCase.builder().orderList(List.of(orderListValue)).build();
@@ -43,14 +44,20 @@ public class OrderDocumentListUtilTest {
 
         //Then
         assertThat(result).isNotNull();
+        assertThat(result).hasSize(1);
+
+        CaseworkerCICDocument orderDocument = result.getFirst();
+        assertThat(orderDocument.getDocumentLink()).isEqualTo(document.getDocumentLink());
+        assertThat(orderDocument.getDate()).isEqualTo(orderSentDate);
     }
 
     @Test
     void shouldGenerateOrderDocTemp() {
         //Given
-
-        Order order = Order.builder().draftOrder(DraftOrderCIC.builder()
-            .templateGeneratedDocument(Document.builder().filename("name").build()).build()).build();
+        Document document = Document.builder().filename("name").build();
+        DraftOrderCIC draftOrder = DraftOrderCIC.builder().templateGeneratedDocument(document).build();
+        LocalDate orderSentDate = LocalDate.of(2026, 4, 20);
+        Order order = Order.builder().draftOrder(draftOrder).orderSentDate(orderSentDate).build();
         ListValue<Order> orderListValue = new ListValue<>();
         orderListValue.setValue(order);
         CicCase cicCase = CicCase.builder().orderList(List.of(orderListValue)).build();
@@ -60,6 +67,11 @@ public class OrderDocumentListUtilTest {
 
         //Then
         assertThat(result).isNotNull();
+        assertThat(result).hasSize(1);
+
+        CaseworkerCICDocument orderDocument = result.getFirst();
+        assertThat(orderDocument.getDocumentLink()).isEqualTo(document);
+        assertThat(orderDocument.getDate()).isEqualTo(orderSentDate);
     }
 
     @Test


### PR DESCRIPTION
### Change description ###
- Add dates to documents when bundling or converting from other document types for the bundle.
- added a date field to decisions
- added a date field to final decisions 

### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSSTCI-1758

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket has been reviewed by QA
- [ ] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

