### PR TITLE
Add local scripts for CCD definitions and DMN deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ TASK_NAME=SystemProgressHeldCasesTask java -jar sptribs-case-api.jar
 # or
 TASK_NAME=SystemProgressHeldCasesTask ./gradlew bootRun
 ```
+## Scripts
+`generate-env-ccd-definition.sh` can be used to generate a local copy of definition files for manual uploads per environment
+
+`deploy-demo-dmn.sh` can be used to manually deploy local DMN files to Demo environment
 
 ## License
 

--- a/bin/generate-env-ccd-definition.sh
+++ b/bin/generate-env-ccd-definition.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eu
+
+ENV=${1:-dev}
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+REPO_ROOT=$(realpath "$SCRIPT_DIR/..")
+ENV_FILE="$SCRIPT_DIR/local-ccd-config-env/target-env.${ENV}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  source "$ENV_FILE"
+fi
+
+cd "$REPO_ROOT"
+
+echo "Generating CCD config for environment: ${ENV}"
+
+./gradlew generateCCDConfig --rerun-tasks
+
+echo "Generating CCD definition (xlsx)"
+./bin/ccd-build-definition.sh
+
+echo "Done - output in build/ccd-config"

--- a/bin/local-ccd-config-env/target-env.aat
+++ b/bin/local-ccd-config-env/target-env.aat
@@ -1,0 +1,3 @@
+export ENVIRONMENT="aat"
+export CASE_API_URL="http://sptribs-case-api-aat.service.core-compute-aat.internal"
+export CCD_DEF_NAME="aat"

--- a/bin/local-ccd-config-env/target-env.demo
+++ b/bin/local-ccd-config-env/target-env.demo
@@ -1,0 +1,3 @@
+export ENVIRONMENT="demo"
+export CASE_API_URL="http://sptribs-case-api-demo.service.core-compute-demo.internal/"
+export CCD_DEF_NAME="demo"

--- a/bin/wa/deploy-demo-dmn.sh
+++ b/bin/wa/deploy-demo-dmn.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#Local convenience wrapper for demo deployments of DMN files for WA
+#Wraps the pipeline deploy script with demo specific values
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+REPO_ROOT=$(realpath "$SCRIPT_DIR/..")
+ENV="demo"
+TENANT_ID="st_cic"
+PRODUCT="st_cic"
+
+export ENVIRONMENT="$ENV"
+export CAMUNDA_BASE_URL="http://camunda-api-demo.service.core-compute-demo.internal"
+export S2S_SECRET=$(az keyvault secret show \
+  --vault-name sptribs-demo \
+  --name s2s-case-api-secret \
+  --query value -o tsv)
+
+bash "$REPO_ROOT/bin/wa/import-dmn-diagram.sh" \
+  "$REPO_ROOT" \
+  "$ENV" \
+  "$TENANT_ID" \
+  "$PRODUCT"


### PR DESCRIPTION
### Change description ###
Adds the following scripts for ease:
- generate-env-ccd-definition.sh
  - along side the local envs (only urls/file name envs)
  - used to generate definitions (json and xlsx) for the named environment locally
  - this can then be used to compare or manually upload to the relevant ccd-definition-store where needed
- deploy-demo-dmn.sh
  - wraps the dmn deployment used in the pipeline to manually upload to demo for instances where we need a different set of DMNs on Demo 

### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSSTCI-

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)
- [ ] `enable-e2e-tests` label can be used to run the e2e tests before QA handover and before release (required)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket has been reviewed by QA
- [ ] the user story has been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

